### PR TITLE
Rename Parser Function and Update Record Fields For V1.0.0 Release

### DIFF
--- a/iso20022/modules/cash_management/camt.026.001.10.bal
+++ b/iso20022/modules/cash_management/camt.026.001.10.bal
@@ -58,8 +58,8 @@ public type MissingData1Choice record {|
 # + IncrrctInf - The incorrect information details
 public type MissingOrIncorrectData1 record {|
     AMLIndicator AMLReq?;
-    UnableToApplyMissing2[10] MssngInf?;
-    UnableToApplyIncorrect2[10] IncrrctInf?;
+    UnableToApplyMissing2[] MssngInf?;
+    UnableToApplyIncorrect2[] IncrrctInf?;
 |};
 
 # Defines the UnableToApplyIncorrect2 structure.

--- a/iso20022/modules/cash_management/camt.028.001.12.bal
+++ b/iso20022/modules/cash_management/camt.028.001.12.bal
@@ -118,6 +118,6 @@ public type PaymentComplementaryInformation11 record {|
     CashAccount40 PrvsInstgAgt3Acct?;
     InstructionForNextAgent1[] InstrForNxtAgt?;
     InstructionForCreditorAgent3[] InstrForCdtrAgt?;
-    RemittanceLocation8[10] RltdRmtInf?;
+    RemittanceLocation8[] RltdRmtInf?;
     RemittanceInformation22 RmtInf?;
 |};

--- a/iso20022/modules/cash_management/common_records.bal
+++ b/iso20022/modules/cash_management/common_records.bal
@@ -526,7 +526,7 @@ public type PostalAddress27 record {|
     Max140Text DstrctNm?;
     Max35Text CtrySubDvsn?;
     CountryCode Ctry?;
-    Max70Text[7] AdrLine?;
+    Max70Text[] AdrLine?;
 |};
 
 public enum PreferredContactMethod2Code {
@@ -1553,7 +1553,7 @@ public type EntryTransaction14 record {|
     LocalInstrument2Choice LclInstrm?;
     PaymentTypeInformation27 PmtTpInf?;
     Purpose2Choice Purp?;
-    RemittanceLocation8[10] RltdRmtInf?;
+    RemittanceLocation8[] RltdRmtInf?;
     RemittanceInformation22 RmtInf?;
     TransactionDates3 RltdDts?;
     TransactionPrice4Choice RltdPric?;

--- a/iso20022/modules/payment_initiation/common_records.bal
+++ b/iso20022/modules/payment_initiation/common_records.bal
@@ -526,7 +526,7 @@ public type PostalAddress27 record {|
     Max140Text DstrctNm?;
     Max35Text CtrySubDvsn?;
     CountryCode Ctry?;
-    Max70Text[7] AdrLine?;
+    Max70Text[] AdrLine?;
 |};
 
 public enum PreferredContactMethod2Code {
@@ -1553,7 +1553,7 @@ public type EntryTransaction14 record {|
     LocalInstrument2Choice LclInstrm?;
     PaymentTypeInformation27 PmtTpInf?;
     Purpose2Choice Purp?;
-    RemittanceLocation8[10] RltdRmtInf?;
+    RemittanceLocation8[] RltdRmtInf?;
     RemittanceInformation22 RmtInf?;
     TransactionDates3 RltdDts?;
     TransactionPrice4Choice RltdPric?;

--- a/iso20022/modules/payment_initiation/pain.008.001.11.bal
+++ b/iso20022/modules/payment_initiation/pain.008.001.11.bal
@@ -62,9 +62,9 @@ public type DirectDebitTransactionInformation32 record {|
     PartyIdentification272 UltmtDbtr?;
     Max140Text InstrForCdtrAgt?;
     Purpose2Choice Purp?;
-    RegulatoryReporting3[10] RgltryRptg?;
+    RegulatoryReporting3[] RgltryRptg?;
     TaxData1 Tax?;
-    RemittanceLocation8[10] RltdRmtInf?;
+    RemittanceLocation8[] RltdRmtInf?;
     RemittanceInformation22 RmtInf?;
     SupplementaryData1[] SplmtryData?;
 |};
@@ -88,7 +88,7 @@ public type Pain008Document record {|
 public type GroupHeader118 record {|
     Max35Text MsgId;
     ISODateTime CreDtTm;
-    Authorisation1Choice[2] Authstn?;
+    Authorisation1Choice[] Authstn?;
     Max15NumericText NbOfTxs;
     DecimalNumber CtrlSum?;
     PartyIdentification272 InitgPty;

--- a/iso20022/modules/payments_clearing_and_settlement/common_records.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/common_records.bal
@@ -526,7 +526,7 @@ public type PostalAddress27 record {|
     Max140Text DstrctNm?;
     Max35Text CtrySubDvsn?;
     CountryCode Ctry?;
-    Max70Text[7] AdrLine?;
+    Max70Text[] AdrLine?;
 |};
 
 public enum PreferredContactMethod2Code {
@@ -1553,7 +1553,7 @@ public type EntryTransaction14 record {|
     LocalInstrument2Choice LclInstrm?;
     PaymentTypeInformation27 PmtTpInf?;
     Purpose2Choice Purp?;
-    RemittanceLocation8[10] RltdRmtInf?;
+    RemittanceLocation8[] RltdRmtInf?;
     RemittanceInformation22 RmtInf?;
     TransactionDates3 RltdDts?;
     TransactionPrice4Choice RltdPric?;

--- a/iso20022/parser.bal
+++ b/iso20022/parser.bal
@@ -9,7 +9,7 @@ import ballerina/data.xmldata;
 # + xmlContent - The XML content to be parsed into the specified record type.
 # + recordType - A `typedesc` representing the Ballerina record type into which the XML will be parsed.
 # + return - The parsed Ballerina record if successful, or an error if the parsing fails.
-public isolated function parseIso20022(xml xmlContent, typedesc<record {}> recordType) returns record {}|error {
+public isolated function fromIso20022(xml xmlContent, typedesc<record {}> recordType) returns record {}|error {
     return xmldata:parseAsType(xmlContent, t = recordType);
 }
 


### PR DESCRIPTION
## Purpose
The purpose of this PR is to rename the parser function to improve readability and to update specific record fields, changing [7] to [] to better reflect the data structure requirements. These modifications are intended to prepare the library for the v1.0.0 release with improved clarity and structural accuracy.

## Goals
The goal is to ensure that the parser function and record fields are optimized for the v1.0.0 release, making the library more intuitive and accurate for users. The updates to record fields, specifically changing [7] to [], address structural needs within the records, ensuring data handling consistency and enhancing compatibility.
