### PR TITLE
Add Name and Namespace to Document Records for ISO 20022 Standards Compatibility

### DIFF
--- a/iso20022/Dependencies.toml
+++ b/iso20022/Dependencies.toml
@@ -57,4 +57,3 @@ modules = [
 	{org = "ballerinax", packageName = "financial.iso20022", moduleName = "financial.iso20022.payment_initiation"},
 	{org = "ballerinax", packageName = "financial.iso20022", moduleName = "financial.iso20022.payments_clearing_and_settlement"}
 ]
-

--- a/iso20022/header.001.001.04.bal
+++ b/iso20022/header.001.001.04.bal
@@ -1,0 +1,459 @@
+import ballerina/data.xmldata;
+
+# Defines the AppHdr type as a reference to BusinessApplicationHeaderV04.
+public type AppHdr BusinessApplicationHeaderV04;
+
+public enum AddressType2Code {
+    ADDR, PBOX, HOME, BIZZ, MLTO, DLVY
+};
+
+# Defines the AddressType3Choice structure.
+#
+# + Cd - Address type as a predefined code
+# + Prtry - Address type as proprietary information
+public type AddressType3Choice record {|
+    AddressType2Code Cd?;
+    GenericIdentification30 Prtry?;
+|};
+
+# Defines the AnyBICDec2014Identifier type as a string.
+public type AnyBICDec2014Identifier string;
+
+# Defines the BICFIDec2014Identifier type as a string.
+public type BICFIDec2014Identifier string;
+
+# Defines the BranchAndFinancialInstitutionIdentification8 structure.
+#
+# + FinInstnId - Identification of the financial institution
+# + BrnchId - Identification of the branch
+public type BranchAndFinancialInstitutionIdentification8 record {|
+    FinancialInstitutionIdentification23 FinInstnId;
+    BranchData5 BrnchId?;
+|};
+
+# Defines the BranchData5 structure.
+#
+# + Id - Branch identifier
+# + LEI - Legal Entity Identifier of the branch
+# + Nm - Name of the branch
+# + PstlAdr - Postal address of the branch
+public type BranchData5 record {|
+    Max35Text Id?;
+    LEIIdentifier LEI?;
+    Max140Text Nm?;
+    PostalAddress27 PstlAdr?;
+|};
+
+# Defines the BusinessApplicationHeader8 structure.
+#
+# + CharSet - Character set used in the message
+# + Fr - Sender of the message
+# + To - Receiver of the message
+# + BizMsgIdr - Business message identifier
+# + MsgDefIdr - Message definition identifier
+# + BizSvc - Business service under which the message is processed
+# + MktPrctc - Market practice rules applicable to the message
+# + CreDt - Creation date and time of the message
+# + BizPrcgDt - Business processing date
+# + CpyDplct - Copy or duplicate indicator
+# + PssblDplct - Possible duplicate indicator
+# + Prty - Business message priority
+# + Sgntr - Digital signature details
+public type BusinessApplicationHeader8 record {|
+    UnicodeChartsCode CharSet?;
+    Party51Choice Fr;
+    Party51Choice To;
+    Max35Text BizMsgIdr;
+    Max35Text MsgDefIdr;
+    Max35Text BizSvc?;
+    ImplementationSpecification1 MktPrctc?;
+    ISODateTime CreDt;
+    ISODateTime BizPrcgDt?;
+    CopyDuplicate1Code CpyDplct?;
+    YesNoIndicator PssblDplct?;
+    BusinessMessagePriorityCode Prty?;
+    SignatureEnvelope Sgntr?;
+|};
+
+# Defines the BusinessApplicationHeaderV04 structure.
+#
+# + CharSet - Character set used in the message
+# + Fr - Sender of the message
+# + To - Receiver of the message
+# + BizMsgIdr - Business message identifier
+# + MsgDefIdr - Message definition identifier
+# + BizSvc - Business service under which the message is processed
+# + MktPrctc - Market practice rules applicable to the message
+# + CreDt - Creation date and time of the message
+# + BizPrcgDt - Business processing date
+# + CpyDplct - Copy or duplicate indicator
+# + PssblDplct - Possible duplicate indicator
+# + Prty - Business message priority
+# + Sgntr - Digital signature details
+# + Rltd - Related business application headers
+@xmldata:Name {
+    value: "AppHdr"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:head.001.001.04"
+}
+public type BusinessApplicationHeaderV04 record {|
+    UnicodeChartsCode CharSet?;
+    Party51Choice Fr;
+    Party51Choice To;
+    Max35Text BizMsgIdr;
+    Max35Text MsgDefIdr;
+    Max35Text BizSvc?;
+    ImplementationSpecification1 MktPrctc?;
+    ISODateTime CreDt;
+    ISODateTime BizPrcgDt?;
+    CopyDuplicate1Code CpyDplct?;
+    YesNoIndicator PssblDplct?;
+    BusinessMessagePriorityCode Prty?;
+    SignatureEnvelope Sgntr?;
+    BusinessApplicationHeader8[] Rltd?;
+|};
+
+# Defines the BusinessMessagePriorityCode type as a string.
+public type BusinessMessagePriorityCode string;
+
+# Defines the ClearingSystemIdentification2Choice structure.
+#
+# + Cd - Clearing system as a predefined code
+# + Prtry - Clearing system as proprietary information
+public type ClearingSystemIdentification2Choice record {|
+    ExternalClearingSystemIdentification1Code Cd?;
+    Max35Text Prtry?;
+|};
+
+# Defines the ClearingSystemMemberIdentification2 structure.
+#
+# + ClrSysId - Identification of the clearing system
+# + MmbId - Member identification within the clearing system
+public type ClearingSystemMemberIdentification2 record {|
+    ClearingSystemIdentification2Choice ClrSysId?;
+    Max35Text MmbId;
+|};
+
+# Defines the Contact13 structure.
+#
+# + NmPrfx - Name prefix
+# + Nm - Name of the contact
+# + PhneNb - Phone number
+# + MobNb - Mobile number
+# + FaxNb - Fax number
+# + URLAdr - URL address
+# + EmailAdr - Email address
+# + EmailPurp - Purpose of the email
+# + JobTitl - Job title
+# + Rspnsblty - Responsibility
+# + Dept - Department
+# + Othr - Other contact details
+# + PrefrdMtd - Preferred contact method
+public type Contact13 record {|
+    NamePrefix2Code NmPrfx?;
+    Max140Text Nm?;
+    PhoneNumber PhneNb?;
+    PhoneNumber MobNb?;
+    PhoneNumber FaxNb?;
+    Max2048Text URLAdr?;
+    Max256Text EmailAdr?;
+    Max35Text EmailPurp?;
+    Max35Text JobTitl?;
+    Max35Text Rspnsblty?;
+    Max70Text Dept?;
+    OtherContact1[] Othr?;
+    PreferredContactMethod2Code PrefrdMtd?;
+|};
+
+public enum CopyDuplicate1Code {
+    CODU, COPY, DUPL
+};
+
+# Defines the CountryCode type as a string.
+public type CountryCode string;
+
+# Defines the DateAndPlaceOfBirth1 structure.
+#
+# + BirthDt - Date of birth
+# + PrvcOfBirth - Province of birth
+# + CityOfBirth - City of birth
+# + CtryOfBirth - Country of birth
+public type DateAndPlaceOfBirth1 record {|
+    ISODate BirthDt;
+    Max35Text PrvcOfBirth?;
+    Max35Text CityOfBirth;
+    CountryCode CtryOfBirth;
+|};
+
+# Defines the Exact4AlphaNumericText type as a string.
+public type Exact4AlphaNumericText string;
+
+# Defines the ExternalClearingSystemIdentification1Code type as a string.
+public type ExternalClearingSystemIdentification1Code string;
+
+# Defines the ExternalFinancialInstitutionIdentification1Code type as a string.
+public type ExternalFinancialInstitutionIdentification1Code string;
+
+# Defines the ExternalOrganisationIdentification1Code type as a string.
+public type ExternalOrganisationIdentification1Code string;
+
+# Defines the ExternalPersonIdentification1Code type as a string.
+public type ExternalPersonIdentification1Code string;
+
+# Defines the FinancialIdentificationSchemeName1Choice structure.
+#
+# + Cd - Financial identification scheme as a predefined code
+# + Prtry - Financial identification scheme as proprietary information
+public type FinancialIdentificationSchemeName1Choice record {|
+    ExternalFinancialInstitutionIdentification1Code Cd?;
+    Max35Text Prtry?;
+|};
+
+# Defines the FinancialInstitutionIdentification23 structure.
+#
+# + BICFI - BIC code of the financial institution
+# + ClrSysMmbId - Member identification in the clearing system
+# + LEI - Legal Entity Identifier of the financial institution
+# + Nm - Name of the financial institution
+# + PstlAdr - Postal address of the financial institution
+# + Othr - Other financial institution identification
+public type FinancialInstitutionIdentification23 record {|
+    BICFIDec2014Identifier BICFI?;
+    ClearingSystemMemberIdentification2 ClrSysMmbId?;
+    LEIIdentifier LEI?;
+    Max140Text Nm?;
+    PostalAddress27 PstlAdr?;
+    GenericFinancialIdentification1 Othr?;
+|};
+
+# Defines the GenericFinancialIdentification1 structure.
+#
+# + Id - Identification value
+# + SchmeNm - Scheme name for the identification
+# + Issr - Issuer of the identification
+public type GenericFinancialIdentification1 record {|
+    Max35Text Id;
+    FinancialIdentificationSchemeName1Choice SchmeNm?;
+    Max35Text Issr?;
+|};
+
+# Defines the GenericIdentification30 structure.
+#
+# + Id - Identification value
+# + Issr - Issuer of the identification
+# + SchmeNm - Scheme name for the identification
+public type GenericIdentification30 record {|
+    Exact4AlphaNumericText Id;
+    Max35Text Issr;
+    Max35Text SchmeNm?;
+|};
+
+# Defines the GenericOrganisationIdentification3 structure.
+#
+# + Id - Identification value
+# + SchmeNm - Scheme name for the identification
+# + Issr - Issuer of the identification
+public type GenericOrganisationIdentification3 record {|
+    Max256Text Id;
+    OrganisationIdentificationSchemeName1Choice SchmeNm?;
+    Max35Text Issr?;
+|};
+
+# Defines the GenericPersonIdentification2 structure.
+#
+# + Id - Identification value
+# + SchmeNm - Scheme name for the identification
+# + Issr - Issuer of the identification
+public type GenericPersonIdentification2 record {|
+    Max256Text Id;
+    PersonIdentificationSchemeName1Choice SchmeNm?;
+    Max35Text Issr?;
+|};
+
+# Defines the ISODate type as a string.
+public type ISODate string;
+
+# Defines the ISODateTime type as a string.
+public type ISODateTime string;
+
+# Defines the ImplementationSpecification1 structure.
+#
+# + Regy - Registry associated with the specification
+# + Id - Identification of the specification
+public type ImplementationSpecification1 record {|
+    Max350Text Regy;
+    Max2048Text Id;
+|};
+
+# Defines the LEIIdentifier type as a string.
+public type LEIIdentifier string;
+
+# Defines the Max128Text type as a string.
+public type Max128Text string;
+
+# Defines the Max140Text type as a string.
+public type Max140Text string;
+
+# Defines the Max16Text type as a string.
+public type Max16Text string;
+
+# Defines the Max2048Text type as a string.
+public type Max2048Text string;
+
+# Defines the Max256Text type as a string.
+public type Max256Text string;
+
+# Defines the Max350Text type as a string.
+public type Max350Text string;
+
+# Defines the Max35Text type as a string.
+public type Max35Text string;
+
+# Defines the Max4Text type as a string.
+public type Max4Text string;
+
+# Defines the Max70Text type as a string.
+public type Max70Text string;
+
+public enum NamePrefix2Code {
+    DOCT, MADM, MISS, MIST, MIKS
+};
+
+# Defines the OrganisationIdentification39 structure.
+#
+# + AnyBIC - BIC of the organisation
+# + LEI - Legal Entity Identifier of the organisation
+# + Othr - Other organisation identification
+public type OrganisationIdentification39 record {|
+    AnyBICDec2014Identifier AnyBIC?;
+    LEIIdentifier LEI?;
+    GenericOrganisationIdentification3[] Othr?;
+|};
+
+# Defines the OrganisationIdentificationSchemeName1Choice structure.
+#
+# + Cd - Organisation identification scheme as a predefined code
+# + Prtry - Organisation identification scheme as proprietary information
+public type OrganisationIdentificationSchemeName1Choice record {|
+    ExternalOrganisationIdentification1Code Cd?;
+    Max35Text Prtry?;
+|};
+
+# Defines the OtherContact1 structure.
+#
+# + ChanlTp - Type of contact channel
+# + Id - Identifier of the contact channel
+public type OtherContact1 record {|
+    Max4Text ChanlTp;
+    Max128Text Id?;
+|};
+
+# Defines the Party51Choice structure.
+#
+# + OrgId - Organisation identification
+# + FIId - Financial institution identification
+public type Party51Choice record {|
+    PartyIdentification272 OrgId?;
+    BranchAndFinancialInstitutionIdentification8 FIId?;
+|};
+
+# Defines the Party52Choice structure.
+#
+# + OrgId - Organisation identification
+# + PrvtId - Private individual identification
+public type Party52Choice record {|
+    OrganisationIdentification39 OrgId?;
+    PersonIdentification18 PrvtId?;
+|};
+
+# Defines the PartyIdentification272 structure.
+#
+# + Nm - Name of the party
+# + PstlAdr - Postal address of the party
+# + Id - Identification of the party
+# + CtryOfRes - Country of residence of the party
+# + CtctDtls - Contact details of the party
+public type PartyIdentification272 record {|
+    Max140Text Nm?;
+    PostalAddress27 PstlAdr?;
+    Party52Choice Id?;
+    CountryCode CtryOfRes?;
+    Contact13 CtctDtls?;
+|};
+
+# Defines the PersonIdentification18 structure.
+#
+# + DtAndPlcOfBirth - Date and place of birth
+# + Othr - Other person identification
+public type PersonIdentification18 record {|
+    DateAndPlaceOfBirth1 DtAndPlcOfBirth?;
+    GenericPersonIdentification2[] Othr?;
+|};
+
+# Defines the PersonIdentificationSchemeName1Choice structure.
+#
+# + Cd - Person identification scheme as a predefined code
+# + Prtry - Person identification scheme as proprietary information
+public type PersonIdentificationSchemeName1Choice record {|
+    ExternalPersonIdentification1Code Cd?;
+    Max35Text Prtry?;
+|};
+
+# Defines the PhoneNumber type as a string.
+public type PhoneNumber string;
+
+# Defines the PostalAddress27 structure.
+#
+# + AdrTp - Address type
+# + CareOf - Care of address details
+# + Dept - Department details
+# + SubDept - Sub-department details
+# + StrtNm - Street name
+# + BldgNb - Building number
+# + BldgNm - Building name
+# + Flr - Floor details
+# + UnitNb - Unit number
+# + PstBx - Postbox number
+# + Room - Room details
+# + PstCd - Postal code
+# + TwnNm - Town name
+# + TwnLctnNm - Town location name
+# + DstrctNm - District name
+# + CtrySubDvsn - Country subdivision
+# + Ctry - Country code
+# + AdrLine - Address line details
+public type PostalAddress27 record {|
+    AddressType3Choice AdrTp?;
+    Max140Text CareOf?;
+    Max70Text Dept?;
+    Max70Text SubDept?;
+    Max140Text StrtNm?;
+    Max16Text BldgNb?;
+    Max140Text BldgNm?;
+    Max70Text Flr?;
+    Max16Text UnitNb?;
+    Max16Text PstBx?;
+    Max70Text Room?;
+    Max16Text PstCd?;
+    Max140Text TwnNm?;
+    Max140Text TwnLctnNm?;
+    Max140Text DstrctNm?;
+    Max35Text CtrySubDvsn?;
+    CountryCode Ctry?;
+    Max70Text[7] AdrLine?;
+|};
+
+public enum PreferredContactMethod2Code {
+    MAIL, FAXX, LETT, CELL, ONLI, PHON
+};
+
+# Defines the SignatureEnvelope structure.
+# Represents the signature envelope details.
+public type SignatureEnvelope record {};
+
+# Defines the UnicodeChartsCode type as a string.
+public type UnicodeChartsCode string;
+
+# Defines the YesNoIndicator type as a boolean.
+public type YesNoIndicator boolean;

--- a/iso20022/modules/cash_management/camt.026.001.10.bal
+++ b/iso20022/modules/cash_management/camt.026.001.10.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the Camt026Document1 structure.
 public type Camt026Document1 Camt026Document;
@@ -23,6 +24,12 @@ public type AMLIndicator boolean;
 # Defines the Camt026Document structure.
 #
 # + UblToApply - The unable to apply information
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.026.001.10"
+}
 public type Camt026Document record {|
     UnableToApplyV10 UblToApply;
 |};

--- a/iso20022/modules/cash_management/camt.027.001.10.bal
+++ b/iso20022/modules/cash_management/camt.027.001.10.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the Camt027Document1 structure.
 public type Camt027Document1 Camt027Document;
@@ -37,6 +38,12 @@ public type ClaimNonReceiptV10 record {|
 # Defines the Camt027Document structure.
 #
 # + ClmNonRct - Claim non-receipt details
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.027.001.10"
+}
 public type Camt027Document record {|
     ClaimNonReceiptV10 ClmNonRct;
 |};

--- a/iso20022/modules/cash_management/camt.028.001.12.bal
+++ b/iso20022/modules/cash_management/camt.028.001.12.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the Camt028Document123 structure.
 public type Camt028Document123 Camt028Document;
@@ -35,6 +36,12 @@ public type AdditionalPaymentInformationV12 record {|
 # Defines the Camt028Document structure.
 #
 # + AddtlPmtInf - Additional payment information details
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.028.001.12"
+}
 public type Camt028Document record {|
     AdditionalPaymentInformationV12 AddtlPmtInf;
 |};

--- a/iso20022/modules/cash_management/camt.029.001.13.bal
+++ b/iso20022/modules/cash_management/camt.029.001.13.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the Camt029Document1 structure.
 public type Camt029Document1 Camt029Document;
@@ -170,6 +171,12 @@ public type CorrectiveTransaction5Choice record {|
 # Defines the Camt029Document structure.
 #
 # + RsltnOfInvstgtn - The resolution of the investigation details
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.029.001.13"
+}
 public type Camt029Document record {|
     ResolutionOfInvestigationV13 RsltnOfInvstgtn;
 |};

--- a/iso20022/modules/cash_management/camt.031.001.07.bal
+++ b/iso20022/modules/cash_management/camt.031.001.07.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Camt031Document1.
 public type Camt031Document1 Camt031Document;
@@ -20,6 +21,12 @@ public type Camt031Document1 Camt031Document;
 # Defines the structure for Camt031Document, a record that holds the rejection investigation details.
 #
 # + RjctInvstgtn - The rejection investigation details
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.031.001.07"
+}
 public type Camt031Document record {|
     RejectInvestigationV07 RjctInvstgtn;
 |};

--- a/iso20022/modules/cash_management/camt.033.001.07.bal
+++ b/iso20022/modules/cash_management/camt.033.001.07.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Camt033Document1.
 public type Camt033Document1 Camt033Document;
@@ -20,6 +21,12 @@ public type Camt033Document1 Camt033Document;
 # Defines the structure for Camt033Document, a record that holds the request for duplicate message details.
 #
 # + ReqForDplct - The request for a duplicate of the previously sent message
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.033.001.07"
+}
 public type Camt033Document record {|
     RequestForDuplicateV07 ReqForDplct;
 |};

--- a/iso20022/modules/cash_management/camt.034.001.07.bal
+++ b/iso20022/modules/cash_management/camt.034.001.07.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Camt034Document1.
 public type Camt034Document1 Camt034Document;
@@ -20,6 +21,12 @@ public type Camt034Document1 Camt034Document;
 # Defines the structure for Camt034Document, a record that holds the duplicate message details.
 #
 # + Dplct - The duplicate message content with its case and proprietary data
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.034.001.07"
+}
 public type Camt034Document record {|
     DuplicateV07 Dplct;
 |};

--- a/iso20022/modules/cash_management/camt.050.001.07.bal
+++ b/iso20022/modules/cash_management/camt.050.001.07.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Camt050Document1.
 public type Camt050Document1 Camt050Document;
@@ -29,6 +30,12 @@ public type Amount2Choice record {|
 # Defines the structure for the Camt050Document, which contains liquidity credit transfer details.
 #
 # + LqdtyCdtTrf - The liquidity credit transfer message details
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.050.001.07"
+}
 public type Camt050Document record {|
     LiquidityCreditTransferV07 LqdtyCdtTrf;
 |};

--- a/iso20022/modules/cash_management/camt.052.001.12.bal
+++ b/iso20022/modules/cash_management/camt.052.001.12.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Camt052Document1.
 public type Camt052Document1 Camt052Document;
@@ -68,6 +69,12 @@ public type BankToCustomerAccountReportV12 record {|
 # Defines the structure for the Camt052Document, which contains the bank-to-customer account report details.
 #
 # + BkToCstmrAcctRpt - The bank-to-customer account report
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.052.001.12"
+}
 public type Camt052Document record {|
     BankToCustomerAccountReportV12 BkToCstmrAcctRpt;
 |};

--- a/iso20022/modules/cash_management/camt.053.001.12.bal
+++ b/iso20022/modules/cash_management/camt.053.001.12.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Camt053Document1.
 public type Camt053Document1 Camt053Document;
@@ -68,6 +69,12 @@ public type BankToCustomerStatementV12 record {|
 # Defines the structure for the Camt053Document, which contains the bank-to-customer statement details.
 #
 # + BkToCstmrStmt - The bank-to-customer statement
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.053.001.12"
+}
 public type Camt053Document record {|
     BankToCustomerStatementV12 BkToCstmrStmt;
 |};

--- a/iso20022/modules/cash_management/camt.054.001.12.bal
+++ b/iso20022/modules/cash_management/camt.054.001.12.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Camt054Document1.
 public type Camt054Document1 Camt054Document;
@@ -66,6 +67,12 @@ public type BankToCustomerDebitCreditNotificationV12 record {|
 # Defines the structure for the Camt054Document, which contains the bank-to-customer debit/credit notification details.
 #
 # + BkToCstmrDbtCdtNtfctn - The bank-to-customer debit/credit notification
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.054.001.12"
+}
 public type Camt054Document record {|
     BankToCustomerDebitCreditNotificationV12 BkToCstmrDbtCdtNtfctn;
 |};

--- a/iso20022/modules/cash_management/camt.055.001.12.bal
+++ b/iso20022/modules/cash_management/camt.055.001.12.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Camt055Document1.
 public type Camt055Document1 Camt055Document;
@@ -35,6 +36,12 @@ public type CustomerPaymentCancellationRequestV12 record {|
 # Defines the structure for Camt055Document, which contains the customer payment cancellation request details.
 #
 # + CstmrPmtCxlReq - The customer payment cancellation request
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.055.001.12"
+}
 public type Camt055Document record {|
     CustomerPaymentCancellationRequestV12 CstmrPmtCxlReq;
 |};

--- a/iso20022/modules/cash_management/camt.056.001.11.bal
+++ b/iso20022/modules/cash_management/camt.056.001.11.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Camt056Document1.
 public type Camt056Document1 Camt056Document;
@@ -20,6 +21,12 @@ public type Camt056Document1 Camt056Document;
 # Defines the structure for Camt056Document, which contains the FI to FI payment cancellation request details.
 #
 # + FIToFIPmtCxlReq - The FI to FI payment cancellation request
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.056.001.11"
+}
 public type Camt056Document record {|
     FIToFIPaymentCancellationRequestV11 FIToFIPmtCxlReq;
 |};

--- a/iso20022/modules/cash_management/camt.057.001.08.bal
+++ b/iso20022/modules/cash_management/camt.057.001.08.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Camt057Document1.
 public type Camt057Document1 Camt057Document;
@@ -47,6 +48,12 @@ public type AccountNotification23 record {|
 # Defines the structure for Camt057Document, which contains the notification to receive details.
 #
 # + NtfctnToRcv - The notification to receive
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.057.001.08"
+}
 public type Camt057Document record {|
     NotificationToReceiveV08 NtfctnToRcv;
 |};

--- a/iso20022/modules/cash_management/camt.060.001.07.bal
+++ b/iso20022/modules/cash_management/camt.060.001.07.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Camt060Document1.
 public type Camt060Document1 Camt060Document;
@@ -40,6 +41,12 @@ public type DatePeriod3 record {|
 # Defines the structure for Camt060Document, which encapsulates the account reporting request details.
 #
 # + AcctRptgReq - Account reporting request information
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:camt.060.001.07"
+}
 public type Camt060Document record {|
     AccountReportingRequestV07 AcctRptgReq;
 |};

--- a/iso20022/modules/cash_management/common_records.bal
+++ b/iso20022/modules/cash_management/common_records.bal
@@ -561,7 +561,7 @@ public type SupplementaryData1 record {|
 |};
 
 # Defines SupplementaryDataEnvelope1 as an empty record for supplementary data.
-# 
+#
 # + Nrtv - Narrative content
 # + XmlContent - Xml content 
 # + CpOfOrgnlMsg - Copy of original message
@@ -1040,7 +1040,7 @@ public type AccountInterest4 record {|
 |};
 
 # Defines the structure for ActiveCurrencyAndAmount_SimpleType, representing an amount in a specific currency.
-# 
+#
 # + ActiveCurrencyAndAmount_SimpleType - The amount in a specified currency.
 # + Ccy - The currency code as an XML attribute.
 public type ActiveCurrencyAndAmount_SimpleType record {|
@@ -1132,7 +1132,7 @@ public type AmountAndDirection35 record {|
 |};
 
 # Defines the structure for AmountRangeBoundary1, representing a boundary for an amount range.
-# 
+#
 # + BdryAmt - The boundary amount.
 # + Incl - Indicates if the boundary is inclusive.
 public type AmountRangeBoundary1 record {|
@@ -1382,7 +1382,7 @@ public enum ChargeBearerType1Code {
     DEBT, CRED, SHAR, SLEV
 };
 
-#Defines the charge included indicator as a boolean.
+# Defines the charge included indicator as a boolean.
 public type ChargeIncludedIndicator boolean;
 
 # Defines the structure for ChargeType3Choice, providing a choice between external code or proprietary charge type.
@@ -1471,8 +1471,8 @@ public type DateAndDateTime2Choice record {|
 
 # Defines the structure for DateOrDateTimePeriod1Choice, offering a choice between a date period or a date-time period.
 #
-# + Dt    - Date period.
-# + DtTm  - Date-time period.
+# + Dt - Date period.
+# + DtTm - Date-time period.
 public type DateOrDateTimePeriod1Choice record {|
     DatePeriod2 Dt?;
     DateTimePeriod1 DtTm?;
@@ -1492,9 +1492,9 @@ public type DecimalNumber decimal;
 
 # Defines the structure for DisplayCapabilities1, specifying user interface display capabilities.
 #
-# + DispTp     - Type of user interface.
-# + NbOfLines  - Number of display lines.
-# + LineWidth  - Width of the display lines.
+# + DispTp - Type of user interface.
+# + NbOfLines - Number of display lines.
+# + LineWidth - Width of the display lines.
 public type DisplayCapabilities1 record {|
     UserInterface2Code DispTp;
     Max3NumericText NbOfLines;
@@ -1503,7 +1503,7 @@ public type DisplayCapabilities1 record {|
 
 # Defines the structure for EntryDetails13, containing details of batch and transaction information.
 #
-# + Btch   - Batch information.
+# + Btch - Batch information.
 # + TxDtls - List of transaction details.
 public type EntryDetails13 record {|
     BatchInformation2 Btch?;
@@ -1512,33 +1512,33 @@ public type EntryDetails13 record {|
 
 # Defines the structure for EntryTransaction14, representing details of a single entry transaction.
 #
-# + Refs       - Transaction references.
-# + Amt        - Transaction amount.
-# + CdtDbtInd  - Credit or debit indicator.
-# + AmtDtls    - Details of the amount and currency exchange.
-# + Avlbty     - Availability of cash.
-# + BkTxCd     - Bank transaction code structure.
-# + Chrgs      - Charges associated with the transaction.
-# + Intrst     - Interest information.
-# + RltdPties  - Related transaction parties.
-# + RltdAgts   - Related transaction agents.
-# + LclInstrm  - Local instrument choice.
-# + PmtTpInf   - Payment type information.
-# + Purp       - Purpose of the transaction.
+# + Refs - Transaction references.
+# + Amt - Transaction amount.
+# + CdtDbtInd - Credit or debit indicator.
+# + AmtDtls - Details of the amount and currency exchange.
+# + Avlbty - Availability of cash.
+# + BkTxCd - Bank transaction code structure.
+# + Chrgs - Charges associated with the transaction.
+# + Intrst - Interest information.
+# + RltdPties - Related transaction parties.
+# + RltdAgts - Related transaction agents.
+# + LclInstrm - Local instrument choice.
+# + PmtTpInf - Payment type information.
+# + Purp - Purpose of the transaction.
 # + RltdRmtInf - Related remittance information (up to 10 instances).
-# + RmtInf     - Remittance information.
-# + RltdDts    - Related transaction dates.
-# + RltdPric   - Related transaction price.
-# + RltdQties  - Related transaction quantities.
-# + FinInstrmId- Financial instrument identification.
-# + Tax        - Tax data.
-# + RtrInf     - Payment return reason information.
-# + CorpActn   - Corporate action details.
-# + SfkpgAcct  - Securities safekeeping account.
-# + CshDpst    - Cash deposit information.
-# + CardTx     - Card transaction information.
+# + RmtInf - Remittance information.
+# + RltdDts - Related transaction dates.
+# + RltdPric - Related transaction price.
+# + RltdQties - Related transaction quantities.
+# + FinInstrmId - Financial instrument identification.
+# + Tax - Tax data.
+# + RtrInf - Payment return reason information.
+# + CorpActn - Corporate action details.
+# + SfkpgAcct - Securities safekeeping account.
+# + CshDpst - Cash deposit information.
+# + CardTx - Card transaction information.
 # + AddtlTxInf - Additional transaction information.
-# + SplmtryData- Supplementary data.
+# + SplmtryData - Supplementary data.
 public type EntryTransaction14 record {|
     TransactionReferences6 Refs?;
     ActiveOrHistoricCurrencyAndAmount Amt?;
@@ -1617,7 +1617,7 @@ public type ExternalTechnicalInputChannel1Code string;
 # Defines the structure for FinancialInstrumentQuantity1Choice, offering a choice between different quantity types for a financial instrument.
 #
 # + Unit - Unit quantity.
-# + FaceAmt  - Face amount.
+# + FaceAmt - Face amount.
 # + AmtsdVal - Amortized value.
 public type FinancialInstrumentQuantity1Choice record {|
     DecimalNumber Unit?;
@@ -1636,9 +1636,9 @@ public type FromToAmountRange1 record {|
 
 # Defines the structure for GenericIdentification1, representing a generic identifier with an optional scheme name and issuer.
 #
-# + Id      - Identifier.
+# + Id - Identifier.
 # + SchmeNm - Scheme name.
-# + Issr    - Issuer.
+# + Issr - Issuer.
 public type GenericIdentification1 record {|
     Max35Text Id?;
     Max35Text SchmeNm?;
@@ -1647,7 +1647,7 @@ public type GenericIdentification1 record {|
 
 # Defines the structure for GenericIdentification3, representing a generic identifier with an issuer.
 #
-# + Id   - Identifier.
+# + Id - Identifier.
 # + Issr - Issuer.
 public type GenericIdentification3 record {|
     Max35Text Id?;
@@ -1656,9 +1656,9 @@ public type GenericIdentification3 record {|
 
 # Defines the structure for GenericIdentification32, representing a generic identifier with a party type, issuer, and short name.
 #
-# + Id     - Identifier.
-# + Tp     - Party type.
-# + Issr   - Issuer.
+# + Id - Identifier.
+# + Tp - Party type.
+# + Issr - Issuer.
 # + ShrtNm - Short name.
 public type GenericIdentification32 record {|
     Max35Text Id;
@@ -1669,12 +1669,12 @@ public type GenericIdentification32 record {|
 
 # Defines the structure for GroupHeader116, representing the header of a message with creation date-time, message recipient, and other optional elements.
 #
-# + MsgId        - Message identifier.
-# + CreDtTm      - Creation date-time.
-# + MsgRcpt      - Message recipient.
-# + MsgPgntn     - Message pagination details.
-# + OrgnlBizQry  - Original business query details.
-# + AddtlInf     - Additional information.
+# + MsgId - Message identifier.
+# + CreDtTm - Creation date-time.
+# + MsgRcpt - Message recipient.
+# + MsgPgntn - Message pagination details.
+# + OrgnlBizQry - Original business query details.
+# + AddtlInf - Additional information.
 public type GroupHeader116 record {|
     Max35Text MsgId;
     ISODateTime CreDtTm;
@@ -1695,7 +1695,7 @@ public type ISOYearMonth string;
 
 # Defines the structure for IdentificationSource3Choice, offering a choice between an external code or a proprietary identifier.
 #
-# + Cd    - External code.
+# + Cd - External code.
 # + Prtry - Proprietary identifier.
 public type IdentificationSource3Choice record {|
     ExternalFinancialInstrumentIdentificationType1Code Cd?;
@@ -1704,11 +1704,11 @@ public type IdentificationSource3Choice record {|
 
 # Defines the structure for ImpliedCurrencyAmountRange1Choice, offering a choice between different amount range types.
 #
-# + FrAmt   - From amount boundary.
-# + ToAmt   - To amount boundary.
+# + FrAmt - From amount boundary.
+# + ToAmt - To amount boundary.
 # + FrToAmt - From-to amount range.
-# + EQAmt   - Equal amount.
-# + NEQAmt  - Not equal amount.
+# + EQAmt - Equal amount.
+# + NEQAmt - Not equal amount.
 public type ImpliedCurrencyAmountRange1Choice record {|
     AmountRangeBoundary1 FrAmt?;
     AmountRangeBoundary1 ToAmt?;
@@ -1722,13 +1722,13 @@ public type ImpliedCurrencyAndAmount decimal;
 
 # Defines the structure for InterestRecord2, representing interest details including amount, type, and tax charges.
 #
-# + Amt     - Interest amount.
-# + CdtDbtInd- Credit or debit indicator.
-# + Tp      - Type of interest.
-# + Rate    - Interest rate.
-# + FrToDt  - From-to date-time range for interest.
-# + Rsn     - Reason for interest.
-# + Tax     - Tax charges associated with the interest.
+# + Amt - Interest amount.
+# + CdtDbtInd - Credit or debit indicator.
+# + Tp - Type of interest.
+# + Rate - Interest rate.
+# + FrToDt - From-to date-time range for interest.
+# + Rsn - Reason for interest.
+# + Tax - Tax charges associated with the interest.
 public type InterestRecord2 record {|
     ActiveOrHistoricCurrencyAndAmount Amt;
     CreditDebitCode CdtDbtInd;
@@ -1741,7 +1741,7 @@ public type InterestRecord2 record {|
 
 # Defines the structure for InterestType1Choice, offering a choice between an interest type code and a proprietary identifier.
 #
-# + Cd    - Interest type code.
+# + Cd - Interest type code.
 # + Prtry - Proprietary interest type.
 public type InterestType1Choice record {|
     InterestType1Code Cd?;
@@ -1754,7 +1754,7 @@ public enum InterestType1Code {
 
 # Defines the structure for LocalInstrument2Choice, offering a choice between an external local instrument code and a proprietary identifier.
 #
-# + Cd    - External local instrument code.
+# + Cd - External local instrument code.
 # + Prtry - Proprietary local instrument identifier.
 public type LocalInstrument2Choice record {|
     ExternalLocalInstrument1Code Cd?;
@@ -1785,7 +1785,7 @@ public type Max5NumericText string;
 # Defines the structure for MessageIdentification2, containing identifiers for a message name and message.
 #
 # + MsgNmId - Message name identifier.
-# + MsgId   - Message identifier.
+# + MsgId - Message identifier.
 public type MessageIdentification2 record {|
     Max35Text MsgNmId?;
     Max35Text MsgId?;
@@ -1806,7 +1806,7 @@ public type NonNegativeDecimalNumber decimal;
 # Defines the structure for NumberAndSumOfTransactions1, containing the number of entries and their sum.
 #
 # + NbOfNtries - Number of entries.
-# + Sum        - Sum of the entries.
+# + Sum - Sum of the entries.
 public type NumberAndSumOfTransactions1 record {|
     Max15NumericText NbOfNtries?;
     DecimalNumber Sum?;
@@ -1814,9 +1814,9 @@ public type NumberAndSumOfTransactions1 record {|
 
 # Defines the structure for NumberAndSumOfTransactions4, containing the number of entries, their sum, and the total net entry.
 #
-# + NbOfNtries  - Number of entries.
-# + Sum         - Sum of the entries.
-# + TtlNetNtry  - Total net entry amount and direction.
+# + NbOfNtries - Number of entries.
+# + Sum - Sum of the entries.
+# + TtlNetNtry - Total net entry amount and direction.
 public type NumberAndSumOfTransactions4 record {|
     Max15NumericText NbOfNtries?;
     DecimalNumber Sum?;
@@ -1829,7 +1829,7 @@ public enum OnLineCapability1Code {
 
 # Defines the structure for OriginalAndCurrentQuantities1, representing the original and current quantities of a financial instrument.
 #
-# + FaceAmt  - Original face amount.
+# + FaceAmt - Original face amount.
 # + AmtsdVal - Current amortized value.
 public type OriginalAndCurrentQuantities1 record {|
     ImpliedCurrencyAndAmount FaceAmt;
@@ -1838,9 +1838,9 @@ public type OriginalAndCurrentQuantities1 record {|
 
 # Defines the structure for OriginalBusinessQuery1, containing information about the original business query.
 #
-# + MsgId    - Message identifier.
-# + MsgNmId  - Message name identifier.
-# + CreDtTm  - Creation date-time.
+# + MsgId - Message identifier.
+# + MsgNmId - Message name identifier.
+# + CreDtTm - Creation date-time.
 public type OriginalBusinessQuery1 record {|
     Max35Text MsgId;
     Max35Text MsgNmId?;
@@ -1849,9 +1849,9 @@ public type OriginalBusinessQuery1 record {|
 
 # Defines the structure for OtherIdentification1, representing other identification information including an optional suffix and identification source.
 #
-# + Id   - Identifier.
-# + Sfx  - Suffix.
-# + Tp   - Identification source.
+# + Id - Identifier.
+# + Sfx - Suffix.
+# + Tp - Identification source.
 public type OtherIdentification1 record {|
     Max35Text Id;
     Max16Text Sfx?;
@@ -1864,7 +1864,7 @@ public enum POIComponentType1Code {
 
 # Defines the structure for Pagination1, representing pagination information for a message.
 #
-# + PgNb      - Page number.
+# + PgNb - Page number.
 # + LastPgInd - Indicator of whether this is the last page.
 public type Pagination1 record {|
     Max5NumericText PgNb;
@@ -1881,10 +1881,10 @@ public enum PartyType4Code {
 
 # Defines the structure for PaymentCard4, representing details of a payment card.
 #
-# + PlainCardData   - Plain card data.
-# + CardCtryCd      - Card country code.
-# + CardBrnd        - Card brand.
-# + AddtlCardData   - Additional card data.
+# + PlainCardData - Plain card data.
+# + CardCtryCd - Card country code.
+# + CardBrnd - Card brand.
+# + AddtlCardData - Additional card data.
 public type PaymentCard4 record {|
     PlainCardData1 PlainCardData?;
     Exact3NumericText CardCtryCd?;
@@ -1894,17 +1894,17 @@ public type PaymentCard4 record {|
 
 # Defines the structure for PaymentContext3, representing the context of a payment transaction, including details about the presence of the cardholder, attendance, and authentication.
 #
-# + CardPres         - Indicates if the card was present.
-# + CrdhldrPres      - Indicates if the cardholder was present.
-# + OnLineCntxt      - Indicates if the transaction was online.
-# + AttndncCntxt     - Attendance context.
-# + TxEnvt           - Transaction environment.
-# + TxChanl          - Transaction channel.
-# + AttndntMsgCpbl   - Indicates if the attendant can send messages.
-# + AttndntLang      - Attendant language.
-# + CardDataNtryMd   - Card data entry mode.
-# + FllbckInd        - Indicates if fallback mode was used.
-# + AuthntcnMtd      - Authentication method.
+# + CardPres - Indicates if the card was present.
+# + CrdhldrPres - Indicates if the cardholder was present.
+# + OnLineCntxt - Indicates if the transaction was online.
+# + AttndncCntxt - Attendance context.
+# + TxEnvt - Transaction environment.
+# + TxChanl - Transaction channel.
+# + AttndntMsgCpbl - Indicates if the attendant can send messages.
+# + AttndntLang - Attendant language.
+# + CardDataNtryMd - Card data entry mode.
+# + FllbckInd - Indicates if fallback mode was used.
+# + AuthntcnMtd - Authentication method.
 public type PaymentContext3 record {|
     TrueFalseIndicator CardPres?;
     TrueFalseIndicator CrdhldrPres?;
@@ -1922,9 +1922,9 @@ public type PaymentContext3 record {|
 # Defines the structure for PaymentReturnReason8, representing the reason for a returned payment.
 #
 # + OrgnlBkTxCd - Original bank transaction code.
-# + Orgtr       - Originator.
-# + Rsn         - Return reason.
-# + AddtlInf    - Additional information about the return.
+# + Orgtr - Originator.
+# + Rsn - Return reason.
+# + AddtlInf - Additional information about the return.
 public type PaymentReturnReason8 record {|
     BankTransactionCodeStructure4 OrgnlBkTxCd?;
     PartyIdentification272 Orgtr?;
@@ -1935,11 +1935,11 @@ public type PaymentReturnReason8 record {|
 # Defines the structure for PaymentTypeInformation27, representing payment type information including priority, clearing channel, service level, and category purpose.
 #
 # + InstrPrty - Instruction priority.
-# + ClrChanl  - Clearing channel.
-# + SvcLvl    - Service level.
+# + ClrChanl - Clearing channel.
+# + SvcLvl - Service level.
 # + LclInstrm - Local instrument.
-# + SeqTp     - Sequence type.
-# + CtgyPurp  - Category purpose.
+# + SeqTp - Sequence type.
+# + CtgyPurp - Category purpose.
 public type PaymentTypeInformation27 record {|
     Priority2Code InstrPrty?;
     ClearingChannel2Code ClrChanl?;
@@ -1951,13 +1951,13 @@ public type PaymentTypeInformation27 record {|
 
 # Defines the structure for PlainCardData1, representing the basic details of a payment card.
 #
-# + PAN       - Primary account number.
+# + PAN - Primary account number.
 # + CardSeqNb - Card sequence number.
-# + FctvDt    - Effective date.
-# + XpryDt    - Expiry date.
-# + SvcCd     - Service code.
-# + TrckData  - Track data.
-# + CardSctyCd- Card security code.
+# + FctvDt - Effective date.
+# + XpryDt - Expiry date.
+# + SvcCd - Service code.
+# + TrckData - Track data.
+# + CardSctyCd - Card security code.
 public type PlainCardData1 record {|
     Min8Max28NumericText PAN;
     Min2Max3NumericText CardSeqNb?;
@@ -1970,11 +1970,11 @@ public type PlainCardData1 record {|
 
 # Defines the structure for PointOfInteraction1, representing a point of interaction device.
 #
-# + Id       - POI identification.
-# + SysNm    - System name.
-# + GrpId    - Group identifier.
+# + Id - POI identification.
+# + SysNm - System name.
+# + GrpId - Group identifier.
 # + Cpblties - POI capabilities.
-# + Cmpnt    - POI components.
+# + Cmpnt - POI components.
 public type PointOfInteraction1 record {|
     GenericIdentification32 Id;
     Max70Text SysNm?;
@@ -1985,11 +1985,11 @@ public type PointOfInteraction1 record {|
 
 # Defines the structure for PointOfInteractionCapabilities1, representing the capabilities of a point of interaction device.
 #
-# + CardRdngCpblties      - Card reading capabilities.
+# + CardRdngCpblties - Card reading capabilities.
 # + CrdhldrVrfctnCpblties - Cardholder verification capabilities.
-# + OnLineCpblties        - Online capabilities.
-# + DispCpblties          - Display capabilities.
-# + PrtLineWidth          - Printer line width.
+# + OnLineCpblties - Online capabilities.
+# + DispCpblties - Display capabilities.
+# + PrtLineWidth - Printer line width.
 public type PointOfInteractionCapabilities1 record {|
     CardDataReading1Code[] CardRdngCpblties?;
     CardholderVerificationCapability1Code[] CrdhldrVrfctnCpblties?;
@@ -2001,11 +2001,11 @@ public type PointOfInteractionCapabilities1 record {|
 # Defines the structure for PointOfInteractionComponent1, representing a component of a point of interaction device.
 #
 # + POICmpntTp - Component type.
-# + ManfctrId  - Manufacturer identifier.
-# + Mdl        - Model.
-# + VrsnNb     - Version number.
-# + SrlNb      - Serial number.
-# + ApprvlNb   - Approval numbers.
+# + ManfctrId - Manufacturer identifier.
+# + Mdl - Model.
+# + VrsnNb - Version number.
+# + SrlNb - Serial number.
+# + ApprvlNb - Approval numbers.
 public type PointOfInteractionComponent1 record {|
     POIComponentType1Code POICmpntTp;
     Max35Text ManfctrId?;
@@ -2020,7 +2020,7 @@ public type PositiveNumber decimal;
 
 # Defines the structure for Price7, representing a price in a financial transaction.
 #
-# + Tp  - Type of price (yielded or value type).
+# + Tp - Type of price (yielded or value type).
 # + Val - Price value (rate or amount).
 public type Price7 record {|
     YieldedOrValueType1Choice Tp;
@@ -2030,7 +2030,7 @@ public type Price7 record {|
 # Defines the structure for PriceRateOrAmount3Choice, offering a choice between a percentage rate and a currency amount.
 #
 # + Rate - Percentage rate.
-# + Amt  - Currency amount.
+# + Amt - Currency amount.
 public type PriceRateOrAmount3Choice record {|
     PercentageRate Rate?;
     ActiveOrHistoricCurrencyAnd13DecimalAmount Amt?;
@@ -2046,12 +2046,12 @@ public enum Priority2Code {
 
 # Defines the structure for Product2, representing a product including its code, unit of measure, and price.
 #
-# + PdctCd       - Product code.
-# + UnitOfMeasr  - Unit of measure.
-# + PdctQty      - Product quantity.
-# + UnitPric     - Unit price.
-# + PdctAmt      - Total product amount.
-# + TaxTp        - Tax type.
+# + PdctCd - Product code.
+# + UnitOfMeasr - Unit of measure.
+# + PdctQty - Product quantity.
+# + UnitPric - Unit price.
+# + PdctAmt - Total product amount.
+# + TaxTp - Tax type.
 # + AddtlPdctInf - Additional product information.
 public type Product2 record {|
     Max70Text PdctCd;
@@ -2065,7 +2065,7 @@ public type Product2 record {|
 
 # Defines the structure for ProprietaryAgent5, representing a proprietary agent and its type.
 #
-# + Tp  - Type of agent.
+# + Tp - Type of agent.
 # + Agt - Branch and financial institution identification of the agent.
 public type ProprietaryAgent5 record {|
     Max35Text Tp;
@@ -2074,8 +2074,8 @@ public type ProprietaryAgent5 record {|
 
 # Defines the structure for ProprietaryBankTransactionCodeStructure1, representing a proprietary bank transaction code.
 #
-# + Cd    - Transaction code.
-# + Issr  - Code issuer.
+# + Cd - Transaction code.
+# + Issr - Code issuer.
 public type ProprietaryBankTransactionCodeStructure1 record {|
     Max35Text Cd;
     Max35Text Issr?;
@@ -2083,8 +2083,8 @@ public type ProprietaryBankTransactionCodeStructure1 record {|
 
 # Defines the structure for ProprietaryDate3, representing a proprietary date.
 #
-# + Tp  - Date type.
-# + Dt  - Date value.
+# + Tp - Date type.
+# + Dt - Date value.
 public type ProprietaryDate3 record {|
     Max35Text Tp;
     DateAndDateTime2Choice Dt;
@@ -2092,7 +2092,7 @@ public type ProprietaryDate3 record {|
 
 # Defines the structure for ProprietaryParty6, representing a proprietary party including its type and party details.
 #
-# + Tp  - Party type.
+# + Tp - Party type.
 # + Pty - Party details.
 public type ProprietaryParty6 record {|
     Max35Text Tp;
@@ -2101,7 +2101,7 @@ public type ProprietaryParty6 record {|
 
 # Defines the structure for ProprietaryPrice2, representing a proprietary price.
 #
-# + Tp   - Price type.
+# + Tp - Price type.
 # + Pric - Price amount.
 public type ProprietaryPrice2 record {|
     Max35Text Tp;
@@ -2110,7 +2110,7 @@ public type ProprietaryPrice2 record {|
 
 # Defines the structure for ProprietaryQuantity1, representing a proprietary quantity.
 #
-# + Tp  - Quantity type.
+# + Tp - Quantity type.
 # + Qty - Quantity value.
 public type ProprietaryQuantity1 record {|
     Max35Text Tp;
@@ -2119,7 +2119,7 @@ public type ProprietaryQuantity1 record {|
 
 # Defines the structure for ProprietaryReference1, representing a proprietary reference.
 #
-# + Tp  - Reference type.
+# + Tp - Reference type.
 # + Ref - Reference value.
 public type ProprietaryReference1 record {|
     Max35Text Tp;
@@ -2128,8 +2128,8 @@ public type ProprietaryReference1 record {|
 
 # Defines the structure for Rate4, representing an interest rate or fee rate.
 #
-# + Tp        - Rate type.
-# + VldtyRg   - Validity range for the rate.
+# + Tp - Rate type.
+# + VldtyRg - Validity range for the rate.
 public type Rate4 record {|
     RateType4Choice Tp;
     ActiveOrHistoricCurrencyAndAmountRange2 VldtyRg?;
@@ -2137,8 +2137,8 @@ public type Rate4 record {|
 
 # Defines the structure for RateType4Choice, offering a choice between a percentage rate and an alternative rate type.
 #
-# + Pctg  - Percentage rate.
-# + Othr  - Other rate type.
+# + Pctg - Percentage rate.
+# + Othr - Other rate type.
 public type RateType4Choice record {|
     PercentageRate Pctg?;
     Max35Text Othr?;
@@ -2146,25 +2146,25 @@ public type RateType4Choice record {|
 
 # Defines the structure for ReportEntry14, representing a report entry with various details including amount, status, and charges.
 #
-# + NtryRef         - Entry reference.
-# + Amt             - Entry amount.
-# + CdtDbtInd       - Credit or debit indicator.
-# + RvslInd         - Reversal indicator.
-# + Sts             - Entry status.
-# + BookgDt         - Booking date.
-# + ValDt           - Value date.
-# + AcctSvcrRef     - Account servicer reference.
-# + Avlbty          - Cash availability details.
-# + BkTxCd          - Bank transaction code.
-# + ComssnWvrInd    - Commission waiver indicator.
-# + AddtlInfInd     - Additional information indicator.
-# + AmtDtls         - Amount and currency exchange details.
-# + Chrgs           - Charges applied to the entry.
-# + TechInptChanl   - Technical input channel used.
-# + Intrst          - Interest details.
-# + CardTx          - Card transaction details.
-# + NtryDtls        - Entry details.
-# + AddtlNtryInf    - Additional entry information.
+# + NtryRef - Entry reference.
+# + Amt - Entry amount.
+# + CdtDbtInd - Credit or debit indicator.
+# + RvslInd - Reversal indicator.
+# + Sts - Entry status.
+# + BookgDt - Booking date.
+# + ValDt - Value date.
+# + AcctSvcrRef - Account servicer reference.
+# + Avlbty - Cash availability details.
+# + BkTxCd - Bank transaction code.
+# + ComssnWvrInd - Commission waiver indicator.
+# + AddtlInfInd - Additional information indicator.
+# + AmtDtls - Amount and currency exchange details.
+# + Chrgs - Charges applied to the entry.
+# + TechInptChanl - Technical input channel used.
+# + Intrst - Interest details.
+# + CardTx - Card transaction details.
+# + NtryDtls - Entry details.
+# + AddtlNtryInf - Additional entry information.
 public type ReportEntry14 record {|
     Max35Text NtryRef?;
     ActiveOrHistoricCurrencyAndAmount Amt;
@@ -2189,7 +2189,7 @@ public type ReportEntry14 record {|
 
 # Defines the structure for ReportingSource1Choice, offering a choice between an external reporting source code and a proprietary source.
 #
-# + Cd    - External reporting source code.
+# + Cd - External reporting source code.
 # + Prtry - Proprietary source.
 public type ReportingSource1Choice record {|
     ExternalReportingSource1Code Cd?;
@@ -2198,7 +2198,7 @@ public type ReportingSource1Choice record {|
 
 # Defines the structure for ReturnReason5Choice, offering a choice between an external return reason code and a proprietary reason.
 #
-# + Cd    - External return reason code.
+# + Cd - External return reason code.
 # + Prtry - Proprietary reason.
 public type ReturnReason5Choice record {|
     ExternalReturnReason1Code Cd?;
@@ -2207,9 +2207,9 @@ public type ReturnReason5Choice record {|
 
 # Defines the structure for SecuritiesAccount19, representing a securities account including its identifier, type, and name.
 #
-# + Id   - Account identifier.
-# + Tp   - Account type.
-# + Nm   - Account name.
+# + Id - Account identifier.
+# + Tp - Account type.
+# + Nm - Account name.
 public type SecuritiesAccount19 record {|
     Max35Text Id;
     GenericIdentification30 Tp?;
@@ -2218,9 +2218,9 @@ public type SecuritiesAccount19 record {|
 
 # Defines the structure for SecurityIdentification19, representing security identification details including ISIN and other identifiers.
 #
-# + ISIN   - ISIN identifier.
+# + ISIN - ISIN identifier.
 # + OthrId - Other security identifiers.
-# + Desc   - Security description.
+# + Desc - Security description.
 public type SecurityIdentification19 record {|
     ISINOct2015Identifier ISIN?;
     OtherIdentification1[] OthrId?;
@@ -2233,7 +2233,7 @@ public enum SequenceType3Code {
 
 # Defines the structure for ServiceLevel8Choice, offering a choice between an external service level code and a proprietary service level.
 #
-# + Cd    - External service level code.
+# + Cd - External service level code.
 # + Prtry - Proprietary service level.
 public type ServiceLevel8Choice record {|
     ExternalServiceLevel1Code Cd?;
@@ -2242,9 +2242,9 @@ public type ServiceLevel8Choice record {|
 
 # Defines the structure for TaxCharges2, representing tax charges applied to a transaction.
 #
-# + Id    - Tax identifier.
-# + Rate  - Tax rate.
-# + Amt   - Tax amount.
+# + Id - Tax identifier.
+# + Rate - Tax rate.
+# + Amt - Tax amount.
 public type TaxCharges2 record {|
     Max35Text Id?;
     PercentageRate Rate?;
@@ -2253,7 +2253,7 @@ public type TaxCharges2 record {|
 
 # Defines the structure for TechnicalInputChannel1Choice, offering a choice between an external technical input channel and a proprietary channel.
 #
-# + Cd    - External technical input channel code.
+# + Cd - External technical input channel code.
 # + Prtry - Proprietary input channel.
 public type TechnicalInputChannel1Choice record {|
     ExternalTechnicalInputChannel1Code Cd?;
@@ -2262,10 +2262,10 @@ public type TechnicalInputChannel1Choice record {|
 
 # Defines the structure for TotalTransactions6, representing totals for transactions including credit and debit entries.
 #
-# + TtlNtries            - Total entries.
-# + TtlCdtNtries         - Total credit entries.
-# + TtlDbtNtries         - Total debit entries.
-# + TtlNtriesPerBkTxCd   - Totals per bank transaction code.
+# + TtlNtries - Total entries.
+# + TtlCdtNtries - Total credit entries.
+# + TtlDbtNtries - Total debit entries.
+# + TtlNtriesPerBkTxCd - Totals per bank transaction code.
 public type TotalTransactions6 record {|
     NumberAndSumOfTransactions4 TtlNtries?;
     NumberAndSumOfTransactions1 TtlCdtNtries?;
@@ -2275,15 +2275,15 @@ public type TotalTransactions6 record {|
 
 # Defines the structure for TotalsPerBankTransactionCode5, representing totals for entries per bank transaction code.
 #
-# + NbOfNtries   - Number of entries.
-# + Sum          - Sum of the entries.
-# + TtlNetNtry   - Total net entry.
-# + CdtNtries    - Credit entries.
-# + DbtNtries    - Debit entries.
-# + FcstInd      - Forecast indicator.
-# + BkTxCd       - Bank transaction code.
-# + Avlbty       - Availability information.
-# + Dt           - Date of the entries.
+# + NbOfNtries - Number of entries.
+# + Sum - Sum of the entries.
+# + TtlNetNtry - Total net entry.
+# + CdtNtries - Credit entries.
+# + DbtNtries - Debit entries.
+# + FcstInd - Forecast indicator.
+# + BkTxCd - Bank transaction code.
+# + Avlbty - Availability information.
+# + Dt - Date of the entries.
 public type TotalsPerBankTransactionCode5 record {|
     Max15NumericText NbOfNtries?;
     DecimalNumber Sum?;
@@ -2298,7 +2298,7 @@ public type TotalsPerBankTransactionCode5 record {|
 
 # Defines the structure for TrackData1, representing track data on a payment card.
 #
-# + TrckNb  - Track number.
+# + TrckNb - Track number.
 # + TrckVal - Track value.
 public type TrackData1 record {|
     Exact1NumericText TrckNb?;
@@ -2307,18 +2307,18 @@ public type TrackData1 record {|
 
 # Defines the structure for TransactionAgents6, representing agents involved in a transaction including debtor, creditor, and intermediaries.
 #
-# + InstgAgt    - Instructing agent.
-# + InstdAgt    - Instructed agent.
-# + DbtrAgt     - Debtor agent.
-# + CdtrAgt     - Creditor agent.
-# + IntrmyAgt1  - First intermediary agent.
-# + IntrmyAgt2  - Second intermediary agent.
-# + IntrmyAgt3  - Third intermediary agent.
-# + RcvgAgt     - Receiving agent.
-# + DlvrgAgt    - Delivering agent.
-# + IssgAgt     - Issuing agent.
-# + SttlmPlc    - Settlement place.
-# + Prtry       - Proprietary agents.
+# + InstgAgt - Instructing agent.
+# + InstdAgt - Instructed agent.
+# + DbtrAgt - Debtor agent.
+# + CdtrAgt - Creditor agent.
+# + IntrmyAgt1 - First intermediary agent.
+# + IntrmyAgt2 - Second intermediary agent.
+# + IntrmyAgt3 - Third intermediary agent.
+# + RcvgAgt - Receiving agent.
+# + DlvrgAgt - Delivering agent.
+# + IssgAgt - Issuing agent.
+# + SttlmPlc - Settlement place.
+# + Prtry - Proprietary agents.
 public type TransactionAgents6 record {|
     BranchAndFinancialInstitutionIdentification8 InstgAgt?;
     BranchAndFinancialInstitutionIdentification8 InstdAgt?;

--- a/iso20022/modules/payment_initiation/common_records.bal
+++ b/iso20022/modules/payment_initiation/common_records.bal
@@ -561,7 +561,7 @@ public type SupplementaryData1 record {|
 |};
 
 # Defines SupplementaryDataEnvelope1 as an empty record for supplementary data.
-# 
+#
 # + Nrtv - Narrative content
 # + XmlContent - Xml content 
 # + CpOfOrgnlMsg - Copy of original message
@@ -1040,7 +1040,7 @@ public type AccountInterest4 record {|
 |};
 
 # Defines the structure for ActiveCurrencyAndAmount_SimpleType, representing an amount in a specific currency.
-# 
+#
 # + ActiveCurrencyAndAmount_SimpleType - The amount in a specified currency.
 # + Ccy - The currency code as an XML attribute.
 public type ActiveCurrencyAndAmount_SimpleType record {|
@@ -1132,7 +1132,7 @@ public type AmountAndDirection35 record {|
 |};
 
 # Defines the structure for AmountRangeBoundary1, representing a boundary for an amount range.
-# 
+#
 # + BdryAmt - The boundary amount.
 # + Incl - Indicates if the boundary is inclusive.
 public type AmountRangeBoundary1 record {|
@@ -1382,7 +1382,7 @@ public enum ChargeBearerType1Code {
     DEBT, CRED, SHAR, SLEV
 };
 
-#Defines the charge included indicator as a boolean.
+# Defines the charge included indicator as a boolean.
 public type ChargeIncludedIndicator boolean;
 
 # Defines the structure for ChargeType3Choice, providing a choice between external code or proprietary charge type.
@@ -1471,8 +1471,8 @@ public type DateAndDateTime2Choice record {|
 
 # Defines the structure for DateOrDateTimePeriod1Choice, offering a choice between a date period or a date-time period.
 #
-# + Dt    - Date period.
-# + DtTm  - Date-time period.
+# + Dt - Date period.
+# + DtTm - Date-time period.
 public type DateOrDateTimePeriod1Choice record {|
     DatePeriod2 Dt?;
     DateTimePeriod1 DtTm?;
@@ -1492,9 +1492,9 @@ public type DecimalNumber decimal;
 
 # Defines the structure for DisplayCapabilities1, specifying user interface display capabilities.
 #
-# + DispTp     - Type of user interface.
-# + NbOfLines  - Number of display lines.
-# + LineWidth  - Width of the display lines.
+# + DispTp - Type of user interface.
+# + NbOfLines - Number of display lines.
+# + LineWidth - Width of the display lines.
 public type DisplayCapabilities1 record {|
     UserInterface2Code DispTp;
     Max3NumericText NbOfLines;
@@ -1503,7 +1503,7 @@ public type DisplayCapabilities1 record {|
 
 # Defines the structure for EntryDetails13, containing details of batch and transaction information.
 #
-# + Btch   - Batch information.
+# + Btch - Batch information.
 # + TxDtls - List of transaction details.
 public type EntryDetails13 record {|
     BatchInformation2 Btch?;
@@ -1512,33 +1512,33 @@ public type EntryDetails13 record {|
 
 # Defines the structure for EntryTransaction14, representing details of a single entry transaction.
 #
-# + Refs       - Transaction references.
-# + Amt        - Transaction amount.
-# + CdtDbtInd  - Credit or debit indicator.
-# + AmtDtls    - Details of the amount and currency exchange.
-# + Avlbty     - Availability of cash.
-# + BkTxCd     - Bank transaction code structure.
-# + Chrgs      - Charges associated with the transaction.
-# + Intrst     - Interest information.
-# + RltdPties  - Related transaction parties.
-# + RltdAgts   - Related transaction agents.
-# + LclInstrm  - Local instrument choice.
-# + PmtTpInf   - Payment type information.
-# + Purp       - Purpose of the transaction.
+# + Refs - Transaction references.
+# + Amt - Transaction amount.
+# + CdtDbtInd - Credit or debit indicator.
+# + AmtDtls - Details of the amount and currency exchange.
+# + Avlbty - Availability of cash.
+# + BkTxCd - Bank transaction code structure.
+# + Chrgs - Charges associated with the transaction.
+# + Intrst - Interest information.
+# + RltdPties - Related transaction parties.
+# + RltdAgts - Related transaction agents.
+# + LclInstrm - Local instrument choice.
+# + PmtTpInf - Payment type information.
+# + Purp - Purpose of the transaction.
 # + RltdRmtInf - Related remittance information (up to 10 instances).
-# + RmtInf     - Remittance information.
-# + RltdDts    - Related transaction dates.
-# + RltdPric   - Related transaction price.
-# + RltdQties  - Related transaction quantities.
-# + FinInstrmId- Financial instrument identification.
-# + Tax        - Tax data.
-# + RtrInf     - Payment return reason information.
-# + CorpActn   - Corporate action details.
-# + SfkpgAcct  - Securities safekeeping account.
-# + CshDpst    - Cash deposit information.
-# + CardTx     - Card transaction information.
+# + RmtInf - Remittance information.
+# + RltdDts - Related transaction dates.
+# + RltdPric - Related transaction price.
+# + RltdQties - Related transaction quantities.
+# + FinInstrmId - Financial instrument identification.
+# + Tax - Tax data.
+# + RtrInf - Payment return reason information.
+# + CorpActn - Corporate action details.
+# + SfkpgAcct - Securities safekeeping account.
+# + CshDpst - Cash deposit information.
+# + CardTx - Card transaction information.
 # + AddtlTxInf - Additional transaction information.
-# + SplmtryData- Supplementary data.
+# + SplmtryData - Supplementary data.
 public type EntryTransaction14 record {|
     TransactionReferences6 Refs?;
     ActiveOrHistoricCurrencyAndAmount Amt?;
@@ -1617,7 +1617,7 @@ public type ExternalTechnicalInputChannel1Code string;
 # Defines the structure for FinancialInstrumentQuantity1Choice, offering a choice between different quantity types for a financial instrument.
 #
 # + Unit - Unit quantity.
-# + FaceAmt  - Face amount.
+# + FaceAmt - Face amount.
 # + AmtsdVal - Amortized value.
 public type FinancialInstrumentQuantity1Choice record {|
     DecimalNumber Unit?;
@@ -1636,9 +1636,9 @@ public type FromToAmountRange1 record {|
 
 # Defines the structure for GenericIdentification1, representing a generic identifier with an optional scheme name and issuer.
 #
-# + Id      - Identifier.
+# + Id - Identifier.
 # + SchmeNm - Scheme name.
-# + Issr    - Issuer.
+# + Issr - Issuer.
 public type GenericIdentification1 record {|
     Max35Text Id?;
     Max35Text SchmeNm?;
@@ -1647,7 +1647,7 @@ public type GenericIdentification1 record {|
 
 # Defines the structure for GenericIdentification3, representing a generic identifier with an issuer.
 #
-# + Id   - Identifier.
+# + Id - Identifier.
 # + Issr - Issuer.
 public type GenericIdentification3 record {|
     Max35Text Id?;
@@ -1656,9 +1656,9 @@ public type GenericIdentification3 record {|
 
 # Defines the structure for GenericIdentification32, representing a generic identifier with a party type, issuer, and short name.
 #
-# + Id     - Identifier.
-# + Tp     - Party type.
-# + Issr   - Issuer.
+# + Id - Identifier.
+# + Tp - Party type.
+# + Issr - Issuer.
 # + ShrtNm - Short name.
 public type GenericIdentification32 record {|
     Max35Text Id;
@@ -1669,12 +1669,12 @@ public type GenericIdentification32 record {|
 
 # Defines the structure for GroupHeader116, representing the header of a message with creation date-time, message recipient, and other optional elements.
 #
-# + MsgId        - Message identifier.
-# + CreDtTm      - Creation date-time.
-# + MsgRcpt      - Message recipient.
-# + MsgPgntn     - Message pagination details.
-# + OrgnlBizQry  - Original business query details.
-# + AddtlInf     - Additional information.
+# + MsgId - Message identifier.
+# + CreDtTm - Creation date-time.
+# + MsgRcpt - Message recipient.
+# + MsgPgntn - Message pagination details.
+# + OrgnlBizQry - Original business query details.
+# + AddtlInf - Additional information.
 public type GroupHeader116 record {|
     Max35Text MsgId;
     ISODateTime CreDtTm;
@@ -1695,7 +1695,7 @@ public type ISOYearMonth string;
 
 # Defines the structure for IdentificationSource3Choice, offering a choice between an external code or a proprietary identifier.
 #
-# + Cd    - External code.
+# + Cd - External code.
 # + Prtry - Proprietary identifier.
 public type IdentificationSource3Choice record {|
     ExternalFinancialInstrumentIdentificationType1Code Cd?;
@@ -1704,11 +1704,11 @@ public type IdentificationSource3Choice record {|
 
 # Defines the structure for ImpliedCurrencyAmountRange1Choice, offering a choice between different amount range types.
 #
-# + FrAmt   - From amount boundary.
-# + ToAmt   - To amount boundary.
+# + FrAmt - From amount boundary.
+# + ToAmt - To amount boundary.
 # + FrToAmt - From-to amount range.
-# + EQAmt   - Equal amount.
-# + NEQAmt  - Not equal amount.
+# + EQAmt - Equal amount.
+# + NEQAmt - Not equal amount.
 public type ImpliedCurrencyAmountRange1Choice record {|
     AmountRangeBoundary1 FrAmt?;
     AmountRangeBoundary1 ToAmt?;
@@ -1722,13 +1722,13 @@ public type ImpliedCurrencyAndAmount decimal;
 
 # Defines the structure for InterestRecord2, representing interest details including amount, type, and tax charges.
 #
-# + Amt     - Interest amount.
-# + CdtDbtInd- Credit or debit indicator.
-# + Tp      - Type of interest.
-# + Rate    - Interest rate.
-# + FrToDt  - From-to date-time range for interest.
-# + Rsn     - Reason for interest.
-# + Tax     - Tax charges associated with the interest.
+# + Amt - Interest amount.
+# + CdtDbtInd - Credit or debit indicator.
+# + Tp - Type of interest.
+# + Rate - Interest rate.
+# + FrToDt - From-to date-time range for interest.
+# + Rsn - Reason for interest.
+# + Tax - Tax charges associated with the interest.
 public type InterestRecord2 record {|
     ActiveOrHistoricCurrencyAndAmount Amt;
     CreditDebitCode CdtDbtInd;
@@ -1741,7 +1741,7 @@ public type InterestRecord2 record {|
 
 # Defines the structure for InterestType1Choice, offering a choice between an interest type code and a proprietary identifier.
 #
-# + Cd    - Interest type code.
+# + Cd - Interest type code.
 # + Prtry - Proprietary interest type.
 public type InterestType1Choice record {|
     InterestType1Code Cd?;
@@ -1754,7 +1754,7 @@ public enum InterestType1Code {
 
 # Defines the structure for LocalInstrument2Choice, offering a choice between an external local instrument code and a proprietary identifier.
 #
-# + Cd    - External local instrument code.
+# + Cd - External local instrument code.
 # + Prtry - Proprietary local instrument identifier.
 public type LocalInstrument2Choice record {|
     ExternalLocalInstrument1Code Cd?;
@@ -1785,7 +1785,7 @@ public type Max5NumericText string;
 # Defines the structure for MessageIdentification2, containing identifiers for a message name and message.
 #
 # + MsgNmId - Message name identifier.
-# + MsgId   - Message identifier.
+# + MsgId - Message identifier.
 public type MessageIdentification2 record {|
     Max35Text MsgNmId?;
     Max35Text MsgId?;
@@ -1806,7 +1806,7 @@ public type NonNegativeDecimalNumber decimal;
 # Defines the structure for NumberAndSumOfTransactions1, containing the number of entries and their sum.
 #
 # + NbOfNtries - Number of entries.
-# + Sum        - Sum of the entries.
+# + Sum - Sum of the entries.
 public type NumberAndSumOfTransactions1 record {|
     Max15NumericText NbOfNtries?;
     DecimalNumber Sum?;
@@ -1814,9 +1814,9 @@ public type NumberAndSumOfTransactions1 record {|
 
 # Defines the structure for NumberAndSumOfTransactions4, containing the number of entries, their sum, and the total net entry.
 #
-# + NbOfNtries  - Number of entries.
-# + Sum         - Sum of the entries.
-# + TtlNetNtry  - Total net entry amount and direction.
+# + NbOfNtries - Number of entries.
+# + Sum - Sum of the entries.
+# + TtlNetNtry - Total net entry amount and direction.
 public type NumberAndSumOfTransactions4 record {|
     Max15NumericText NbOfNtries?;
     DecimalNumber Sum?;
@@ -1829,7 +1829,7 @@ public enum OnLineCapability1Code {
 
 # Defines the structure for OriginalAndCurrentQuantities1, representing the original and current quantities of a financial instrument.
 #
-# + FaceAmt  - Original face amount.
+# + FaceAmt - Original face amount.
 # + AmtsdVal - Current amortized value.
 public type OriginalAndCurrentQuantities1 record {|
     ImpliedCurrencyAndAmount FaceAmt;
@@ -1838,9 +1838,9 @@ public type OriginalAndCurrentQuantities1 record {|
 
 # Defines the structure for OriginalBusinessQuery1, containing information about the original business query.
 #
-# + MsgId    - Message identifier.
-# + MsgNmId  - Message name identifier.
-# + CreDtTm  - Creation date-time.
+# + MsgId - Message identifier.
+# + MsgNmId - Message name identifier.
+# + CreDtTm - Creation date-time.
 public type OriginalBusinessQuery1 record {|
     Max35Text MsgId;
     Max35Text MsgNmId?;
@@ -1849,9 +1849,9 @@ public type OriginalBusinessQuery1 record {|
 
 # Defines the structure for OtherIdentification1, representing other identification information including an optional suffix and identification source.
 #
-# + Id   - Identifier.
-# + Sfx  - Suffix.
-# + Tp   - Identification source.
+# + Id - Identifier.
+# + Sfx - Suffix.
+# + Tp - Identification source.
 public type OtherIdentification1 record {|
     Max35Text Id;
     Max16Text Sfx?;
@@ -1864,7 +1864,7 @@ public enum POIComponentType1Code {
 
 # Defines the structure for Pagination1, representing pagination information for a message.
 #
-# + PgNb      - Page number.
+# + PgNb - Page number.
 # + LastPgInd - Indicator of whether this is the last page.
 public type Pagination1 record {|
     Max5NumericText PgNb;
@@ -1881,10 +1881,10 @@ public enum PartyType4Code {
 
 # Defines the structure for PaymentCard4, representing details of a payment card.
 #
-# + PlainCardData   - Plain card data.
-# + CardCtryCd      - Card country code.
-# + CardBrnd        - Card brand.
-# + AddtlCardData   - Additional card data.
+# + PlainCardData - Plain card data.
+# + CardCtryCd - Card country code.
+# + CardBrnd - Card brand.
+# + AddtlCardData - Additional card data.
 public type PaymentCard4 record {|
     PlainCardData1 PlainCardData?;
     Exact3NumericText CardCtryCd?;
@@ -1894,17 +1894,17 @@ public type PaymentCard4 record {|
 
 # Defines the structure for PaymentContext3, representing the context of a payment transaction, including details about the presence of the cardholder, attendance, and authentication.
 #
-# + CardPres         - Indicates if the card was present.
-# + CrdhldrPres      - Indicates if the cardholder was present.
-# + OnLineCntxt      - Indicates if the transaction was online.
-# + AttndncCntxt     - Attendance context.
-# + TxEnvt           - Transaction environment.
-# + TxChanl          - Transaction channel.
-# + AttndntMsgCpbl   - Indicates if the attendant can send messages.
-# + AttndntLang      - Attendant language.
-# + CardDataNtryMd   - Card data entry mode.
-# + FllbckInd        - Indicates if fallback mode was used.
-# + AuthntcnMtd      - Authentication method.
+# + CardPres - Indicates if the card was present.
+# + CrdhldrPres - Indicates if the cardholder was present.
+# + OnLineCntxt - Indicates if the transaction was online.
+# + AttndncCntxt - Attendance context.
+# + TxEnvt - Transaction environment.
+# + TxChanl - Transaction channel.
+# + AttndntMsgCpbl - Indicates if the attendant can send messages.
+# + AttndntLang - Attendant language.
+# + CardDataNtryMd - Card data entry mode.
+# + FllbckInd - Indicates if fallback mode was used.
+# + AuthntcnMtd - Authentication method.
 public type PaymentContext3 record {|
     TrueFalseIndicator CardPres?;
     TrueFalseIndicator CrdhldrPres?;
@@ -1922,9 +1922,9 @@ public type PaymentContext3 record {|
 # Defines the structure for PaymentReturnReason8, representing the reason for a returned payment.
 #
 # + OrgnlBkTxCd - Original bank transaction code.
-# + Orgtr       - Originator.
-# + Rsn         - Return reason.
-# + AddtlInf    - Additional information about the return.
+# + Orgtr - Originator.
+# + Rsn - Return reason.
+# + AddtlInf - Additional information about the return.
 public type PaymentReturnReason8 record {|
     BankTransactionCodeStructure4 OrgnlBkTxCd?;
     PartyIdentification272 Orgtr?;
@@ -1935,11 +1935,11 @@ public type PaymentReturnReason8 record {|
 # Defines the structure for PaymentTypeInformation27, representing payment type information including priority, clearing channel, service level, and category purpose.
 #
 # + InstrPrty - Instruction priority.
-# + ClrChanl  - Clearing channel.
-# + SvcLvl    - Service level.
+# + ClrChanl - Clearing channel.
+# + SvcLvl - Service level.
 # + LclInstrm - Local instrument.
-# + SeqTp     - Sequence type.
-# + CtgyPurp  - Category purpose.
+# + SeqTp - Sequence type.
+# + CtgyPurp - Category purpose.
 public type PaymentTypeInformation27 record {|
     Priority2Code InstrPrty?;
     ClearingChannel2Code ClrChanl?;
@@ -1951,13 +1951,13 @@ public type PaymentTypeInformation27 record {|
 
 # Defines the structure for PlainCardData1, representing the basic details of a payment card.
 #
-# + PAN       - Primary account number.
+# + PAN - Primary account number.
 # + CardSeqNb - Card sequence number.
-# + FctvDt    - Effective date.
-# + XpryDt    - Expiry date.
-# + SvcCd     - Service code.
-# + TrckData  - Track data.
-# + CardSctyCd- Card security code.
+# + FctvDt - Effective date.
+# + XpryDt - Expiry date.
+# + SvcCd - Service code.
+# + TrckData - Track data.
+# + CardSctyCd - Card security code.
 public type PlainCardData1 record {|
     Min8Max28NumericText PAN;
     Min2Max3NumericText CardSeqNb?;
@@ -1970,11 +1970,11 @@ public type PlainCardData1 record {|
 
 # Defines the structure for PointOfInteraction1, representing a point of interaction device.
 #
-# + Id       - POI identification.
-# + SysNm    - System name.
-# + GrpId    - Group identifier.
+# + Id - POI identification.
+# + SysNm - System name.
+# + GrpId - Group identifier.
 # + Cpblties - POI capabilities.
-# + Cmpnt    - POI components.
+# + Cmpnt - POI components.
 public type PointOfInteraction1 record {|
     GenericIdentification32 Id;
     Max70Text SysNm?;
@@ -1985,11 +1985,11 @@ public type PointOfInteraction1 record {|
 
 # Defines the structure for PointOfInteractionCapabilities1, representing the capabilities of a point of interaction device.
 #
-# + CardRdngCpblties      - Card reading capabilities.
+# + CardRdngCpblties - Card reading capabilities.
 # + CrdhldrVrfctnCpblties - Cardholder verification capabilities.
-# + OnLineCpblties        - Online capabilities.
-# + DispCpblties          - Display capabilities.
-# + PrtLineWidth          - Printer line width.
+# + OnLineCpblties - Online capabilities.
+# + DispCpblties - Display capabilities.
+# + PrtLineWidth - Printer line width.
 public type PointOfInteractionCapabilities1 record {|
     CardDataReading1Code[] CardRdngCpblties?;
     CardholderVerificationCapability1Code[] CrdhldrVrfctnCpblties?;
@@ -2001,11 +2001,11 @@ public type PointOfInteractionCapabilities1 record {|
 # Defines the structure for PointOfInteractionComponent1, representing a component of a point of interaction device.
 #
 # + POICmpntTp - Component type.
-# + ManfctrId  - Manufacturer identifier.
-# + Mdl        - Model.
-# + VrsnNb     - Version number.
-# + SrlNb      - Serial number.
-# + ApprvlNb   - Approval numbers.
+# + ManfctrId - Manufacturer identifier.
+# + Mdl - Model.
+# + VrsnNb - Version number.
+# + SrlNb - Serial number.
+# + ApprvlNb - Approval numbers.
 public type PointOfInteractionComponent1 record {|
     POIComponentType1Code POICmpntTp;
     Max35Text ManfctrId?;
@@ -2020,7 +2020,7 @@ public type PositiveNumber decimal;
 
 # Defines the structure for Price7, representing a price in a financial transaction.
 #
-# + Tp  - Type of price (yielded or value type).
+# + Tp - Type of price (yielded or value type).
 # + Val - Price value (rate or amount).
 public type Price7 record {|
     YieldedOrValueType1Choice Tp;
@@ -2030,7 +2030,7 @@ public type Price7 record {|
 # Defines the structure for PriceRateOrAmount3Choice, offering a choice between a percentage rate and a currency amount.
 #
 # + Rate - Percentage rate.
-# + Amt  - Currency amount.
+# + Amt - Currency amount.
 public type PriceRateOrAmount3Choice record {|
     PercentageRate Rate?;
     ActiveOrHistoricCurrencyAnd13DecimalAmount Amt?;
@@ -2046,12 +2046,12 @@ public enum Priority2Code {
 
 # Defines the structure for Product2, representing a product including its code, unit of measure, and price.
 #
-# + PdctCd       - Product code.
-# + UnitOfMeasr  - Unit of measure.
-# + PdctQty      - Product quantity.
-# + UnitPric     - Unit price.
-# + PdctAmt      - Total product amount.
-# + TaxTp        - Tax type.
+# + PdctCd - Product code.
+# + UnitOfMeasr - Unit of measure.
+# + PdctQty - Product quantity.
+# + UnitPric - Unit price.
+# + PdctAmt - Total product amount.
+# + TaxTp - Tax type.
 # + AddtlPdctInf - Additional product information.
 public type Product2 record {|
     Max70Text PdctCd;
@@ -2065,7 +2065,7 @@ public type Product2 record {|
 
 # Defines the structure for ProprietaryAgent5, representing a proprietary agent and its type.
 #
-# + Tp  - Type of agent.
+# + Tp - Type of agent.
 # + Agt - Branch and financial institution identification of the agent.
 public type ProprietaryAgent5 record {|
     Max35Text Tp;
@@ -2074,8 +2074,8 @@ public type ProprietaryAgent5 record {|
 
 # Defines the structure for ProprietaryBankTransactionCodeStructure1, representing a proprietary bank transaction code.
 #
-# + Cd    - Transaction code.
-# + Issr  - Code issuer.
+# + Cd - Transaction code.
+# + Issr - Code issuer.
 public type ProprietaryBankTransactionCodeStructure1 record {|
     Max35Text Cd;
     Max35Text Issr?;
@@ -2083,8 +2083,8 @@ public type ProprietaryBankTransactionCodeStructure1 record {|
 
 # Defines the structure for ProprietaryDate3, representing a proprietary date.
 #
-# + Tp  - Date type.
-# + Dt  - Date value.
+# + Tp - Date type.
+# + Dt - Date value.
 public type ProprietaryDate3 record {|
     Max35Text Tp;
     DateAndDateTime2Choice Dt;
@@ -2092,7 +2092,7 @@ public type ProprietaryDate3 record {|
 
 # Defines the structure for ProprietaryParty6, representing a proprietary party including its type and party details.
 #
-# + Tp  - Party type.
+# + Tp - Party type.
 # + Pty - Party details.
 public type ProprietaryParty6 record {|
     Max35Text Tp;
@@ -2101,7 +2101,7 @@ public type ProprietaryParty6 record {|
 
 # Defines the structure for ProprietaryPrice2, representing a proprietary price.
 #
-# + Tp   - Price type.
+# + Tp - Price type.
 # + Pric - Price amount.
 public type ProprietaryPrice2 record {|
     Max35Text Tp;
@@ -2110,7 +2110,7 @@ public type ProprietaryPrice2 record {|
 
 # Defines the structure for ProprietaryQuantity1, representing a proprietary quantity.
 #
-# + Tp  - Quantity type.
+# + Tp - Quantity type.
 # + Qty - Quantity value.
 public type ProprietaryQuantity1 record {|
     Max35Text Tp;
@@ -2119,7 +2119,7 @@ public type ProprietaryQuantity1 record {|
 
 # Defines the structure for ProprietaryReference1, representing a proprietary reference.
 #
-# + Tp  - Reference type.
+# + Tp - Reference type.
 # + Ref - Reference value.
 public type ProprietaryReference1 record {|
     Max35Text Tp;
@@ -2128,8 +2128,8 @@ public type ProprietaryReference1 record {|
 
 # Defines the structure for Rate4, representing an interest rate or fee rate.
 #
-# + Tp        - Rate type.
-# + VldtyRg   - Validity range for the rate.
+# + Tp - Rate type.
+# + VldtyRg - Validity range for the rate.
 public type Rate4 record {|
     RateType4Choice Tp;
     ActiveOrHistoricCurrencyAndAmountRange2 VldtyRg?;
@@ -2137,8 +2137,8 @@ public type Rate4 record {|
 
 # Defines the structure for RateType4Choice, offering a choice between a percentage rate and an alternative rate type.
 #
-# + Pctg  - Percentage rate.
-# + Othr  - Other rate type.
+# + Pctg - Percentage rate.
+# + Othr - Other rate type.
 public type RateType4Choice record {|
     PercentageRate Pctg?;
     Max35Text Othr?;
@@ -2146,25 +2146,25 @@ public type RateType4Choice record {|
 
 # Defines the structure for ReportEntry14, representing a report entry with various details including amount, status, and charges.
 #
-# + NtryRef         - Entry reference.
-# + Amt             - Entry amount.
-# + CdtDbtInd       - Credit or debit indicator.
-# + RvslInd         - Reversal indicator.
-# + Sts             - Entry status.
-# + BookgDt         - Booking date.
-# + ValDt           - Value date.
-# + AcctSvcrRef     - Account servicer reference.
-# + Avlbty          - Cash availability details.
-# + BkTxCd          - Bank transaction code.
-# + ComssnWvrInd    - Commission waiver indicator.
-# + AddtlInfInd     - Additional information indicator.
-# + AmtDtls         - Amount and currency exchange details.
-# + Chrgs           - Charges applied to the entry.
-# + TechInptChanl   - Technical input channel used.
-# + Intrst          - Interest details.
-# + CardTx          - Card transaction details.
-# + NtryDtls        - Entry details.
-# + AddtlNtryInf    - Additional entry information.
+# + NtryRef - Entry reference.
+# + Amt - Entry amount.
+# + CdtDbtInd - Credit or debit indicator.
+# + RvslInd - Reversal indicator.
+# + Sts - Entry status.
+# + BookgDt - Booking date.
+# + ValDt - Value date.
+# + AcctSvcrRef - Account servicer reference.
+# + Avlbty - Cash availability details.
+# + BkTxCd - Bank transaction code.
+# + ComssnWvrInd - Commission waiver indicator.
+# + AddtlInfInd - Additional information indicator.
+# + AmtDtls - Amount and currency exchange details.
+# + Chrgs - Charges applied to the entry.
+# + TechInptChanl - Technical input channel used.
+# + Intrst - Interest details.
+# + CardTx - Card transaction details.
+# + NtryDtls - Entry details.
+# + AddtlNtryInf - Additional entry information.
 public type ReportEntry14 record {|
     Max35Text NtryRef?;
     ActiveOrHistoricCurrencyAndAmount Amt;
@@ -2189,7 +2189,7 @@ public type ReportEntry14 record {|
 
 # Defines the structure for ReportingSource1Choice, offering a choice between an external reporting source code and a proprietary source.
 #
-# + Cd    - External reporting source code.
+# + Cd - External reporting source code.
 # + Prtry - Proprietary source.
 public type ReportingSource1Choice record {|
     ExternalReportingSource1Code Cd?;
@@ -2198,7 +2198,7 @@ public type ReportingSource1Choice record {|
 
 # Defines the structure for ReturnReason5Choice, offering a choice between an external return reason code and a proprietary reason.
 #
-# + Cd    - External return reason code.
+# + Cd - External return reason code.
 # + Prtry - Proprietary reason.
 public type ReturnReason5Choice record {|
     ExternalReturnReason1Code Cd?;
@@ -2207,9 +2207,9 @@ public type ReturnReason5Choice record {|
 
 # Defines the structure for SecuritiesAccount19, representing a securities account including its identifier, type, and name.
 #
-# + Id   - Account identifier.
-# + Tp   - Account type.
-# + Nm   - Account name.
+# + Id - Account identifier.
+# + Tp - Account type.
+# + Nm - Account name.
 public type SecuritiesAccount19 record {|
     Max35Text Id;
     GenericIdentification30 Tp?;
@@ -2218,9 +2218,9 @@ public type SecuritiesAccount19 record {|
 
 # Defines the structure for SecurityIdentification19, representing security identification details including ISIN and other identifiers.
 #
-# + ISIN   - ISIN identifier.
+# + ISIN - ISIN identifier.
 # + OthrId - Other security identifiers.
-# + Desc   - Security description.
+# + Desc - Security description.
 public type SecurityIdentification19 record {|
     ISINOct2015Identifier ISIN?;
     OtherIdentification1[] OthrId?;
@@ -2233,7 +2233,7 @@ public enum SequenceType3Code {
 
 # Defines the structure for ServiceLevel8Choice, offering a choice between an external service level code and a proprietary service level.
 #
-# + Cd    - External service level code.
+# + Cd - External service level code.
 # + Prtry - Proprietary service level.
 public type ServiceLevel8Choice record {|
     ExternalServiceLevel1Code Cd?;
@@ -2242,9 +2242,9 @@ public type ServiceLevel8Choice record {|
 
 # Defines the structure for TaxCharges2, representing tax charges applied to a transaction.
 #
-# + Id    - Tax identifier.
-# + Rate  - Tax rate.
-# + Amt   - Tax amount.
+# + Id - Tax identifier.
+# + Rate - Tax rate.
+# + Amt - Tax amount.
 public type TaxCharges2 record {|
     Max35Text Id?;
     PercentageRate Rate?;
@@ -2253,7 +2253,7 @@ public type TaxCharges2 record {|
 
 # Defines the structure for TechnicalInputChannel1Choice, offering a choice between an external technical input channel and a proprietary channel.
 #
-# + Cd    - External technical input channel code.
+# + Cd - External technical input channel code.
 # + Prtry - Proprietary input channel.
 public type TechnicalInputChannel1Choice record {|
     ExternalTechnicalInputChannel1Code Cd?;
@@ -2262,10 +2262,10 @@ public type TechnicalInputChannel1Choice record {|
 
 # Defines the structure for TotalTransactions6, representing totals for transactions including credit and debit entries.
 #
-# + TtlNtries            - Total entries.
-# + TtlCdtNtries         - Total credit entries.
-# + TtlDbtNtries         - Total debit entries.
-# + TtlNtriesPerBkTxCd   - Totals per bank transaction code.
+# + TtlNtries - Total entries.
+# + TtlCdtNtries - Total credit entries.
+# + TtlDbtNtries - Total debit entries.
+# + TtlNtriesPerBkTxCd - Totals per bank transaction code.
 public type TotalTransactions6 record {|
     NumberAndSumOfTransactions4 TtlNtries?;
     NumberAndSumOfTransactions1 TtlCdtNtries?;
@@ -2275,15 +2275,15 @@ public type TotalTransactions6 record {|
 
 # Defines the structure for TotalsPerBankTransactionCode5, representing totals for entries per bank transaction code.
 #
-# + NbOfNtries   - Number of entries.
-# + Sum          - Sum of the entries.
-# + TtlNetNtry   - Total net entry.
-# + CdtNtries    - Credit entries.
-# + DbtNtries    - Debit entries.
-# + FcstInd      - Forecast indicator.
-# + BkTxCd       - Bank transaction code.
-# + Avlbty       - Availability information.
-# + Dt           - Date of the entries.
+# + NbOfNtries - Number of entries.
+# + Sum - Sum of the entries.
+# + TtlNetNtry - Total net entry.
+# + CdtNtries - Credit entries.
+# + DbtNtries - Debit entries.
+# + FcstInd - Forecast indicator.
+# + BkTxCd - Bank transaction code.
+# + Avlbty - Availability information.
+# + Dt - Date of the entries.
 public type TotalsPerBankTransactionCode5 record {|
     Max15NumericText NbOfNtries?;
     DecimalNumber Sum?;
@@ -2298,7 +2298,7 @@ public type TotalsPerBankTransactionCode5 record {|
 
 # Defines the structure for TrackData1, representing track data on a payment card.
 #
-# + TrckNb  - Track number.
+# + TrckNb - Track number.
 # + TrckVal - Track value.
 public type TrackData1 record {|
     Exact1NumericText TrckNb?;
@@ -2307,18 +2307,18 @@ public type TrackData1 record {|
 
 # Defines the structure for TransactionAgents6, representing agents involved in a transaction including debtor, creditor, and intermediaries.
 #
-# + InstgAgt    - Instructing agent.
-# + InstdAgt    - Instructed agent.
-# + DbtrAgt     - Debtor agent.
-# + CdtrAgt     - Creditor agent.
-# + IntrmyAgt1  - First intermediary agent.
-# + IntrmyAgt2  - Second intermediary agent.
-# + IntrmyAgt3  - Third intermediary agent.
-# + RcvgAgt     - Receiving agent.
-# + DlvrgAgt    - Delivering agent.
-# + IssgAgt     - Issuing agent.
-# + SttlmPlc    - Settlement place.
-# + Prtry       - Proprietary agents.
+# + InstgAgt - Instructing agent.
+# + InstdAgt - Instructed agent.
+# + DbtrAgt - Debtor agent.
+# + CdtrAgt - Creditor agent.
+# + IntrmyAgt1 - First intermediary agent.
+# + IntrmyAgt2 - Second intermediary agent.
+# + IntrmyAgt3 - Third intermediary agent.
+# + RcvgAgt - Receiving agent.
+# + DlvrgAgt - Delivering agent.
+# + IssgAgt - Issuing agent.
+# + SttlmPlc - Settlement place.
+# + Prtry - Proprietary agents.
 public type TransactionAgents6 record {|
     BranchAndFinancialInstitutionIdentification8 InstgAgt?;
     BranchAndFinancialInstitutionIdentification8 InstdAgt?;

--- a/iso20022/modules/payment_initiation/pain.001.001.12.bal
+++ b/iso20022/modules/payment_initiation/pain.001.001.12.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Pain001Document1.
 public type Pain001Document1 Pain001Document;
@@ -134,6 +135,12 @@ public type CustomerCreditTransferInitiationV12 record {|
 # Defines the structure for Pain001Document, which encapsulates the customer credit transfer initiation information.
 #
 # + CstmrCdtTrfInitn - Customer credit transfer initiation information
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:pain.001.001.12"
+}
 public type Pain001Document record {|
     CustomerCreditTransferInitiationV12 CstmrCdtTrfInitn;
 |};

--- a/iso20022/modules/payment_initiation/pain.008.001.11.bal
+++ b/iso20022/modules/payment_initiation/pain.008.001.11.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Pain008Document1.
 public type Pain008Document1 Pain008Document;
@@ -72,6 +73,12 @@ public type DirectDebitTransactionInformation32 record {|
 # Defines the structure for Pain008Document, which encapsulates the customer direct debit initiation information.
 #
 # + CstmrDrctDbtInitn - Customer direct debit initiation information
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:pain.008.001.11"
+}
 public type Pain008Document record {|
     CustomerDirectDebitInitiationV11 CstmrDrctDbtInitn;
 |};

--- a/iso20022/modules/payments_clearing_and_settlement/common_records.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/common_records.bal
@@ -561,7 +561,7 @@ public type SupplementaryData1 record {|
 |};
 
 # Defines SupplementaryDataEnvelope1 as an empty record for supplementary data.
-# 
+#
 # + Nrtv - Narrative content
 # + XmlContent - Xml content 
 # + CpOfOrgnlMsg - Copy of original message
@@ -1040,7 +1040,7 @@ public type AccountInterest4 record {|
 |};
 
 # Defines the structure for ActiveCurrencyAndAmount_SimpleType, representing an amount in a specific currency.
-# 
+#
 # + ActiveCurrencyAndAmount_SimpleType - The amount in a specified currency.
 # + Ccy - The currency code as an XML attribute.
 public type ActiveCurrencyAndAmount_SimpleType record {|
@@ -1132,7 +1132,7 @@ public type AmountAndDirection35 record {|
 |};
 
 # Defines the structure for AmountRangeBoundary1, representing a boundary for an amount range.
-# 
+#
 # + BdryAmt - The boundary amount.
 # + Incl - Indicates if the boundary is inclusive.
 public type AmountRangeBoundary1 record {|
@@ -1382,7 +1382,7 @@ public enum ChargeBearerType1Code {
     DEBT, CRED, SHAR, SLEV
 };
 
-#Defines the charge included indicator as a boolean.
+# Defines the charge included indicator as a boolean.
 public type ChargeIncludedIndicator boolean;
 
 # Defines the structure for ChargeType3Choice, providing a choice between external code or proprietary charge type.
@@ -1471,8 +1471,8 @@ public type DateAndDateTime2Choice record {|
 
 # Defines the structure for DateOrDateTimePeriod1Choice, offering a choice between a date period or a date-time period.
 #
-# + Dt    - Date period.
-# + DtTm  - Date-time period.
+# + Dt - Date period.
+# + DtTm - Date-time period.
 public type DateOrDateTimePeriod1Choice record {|
     DatePeriod2 Dt?;
     DateTimePeriod1 DtTm?;
@@ -1492,9 +1492,9 @@ public type DecimalNumber decimal;
 
 # Defines the structure for DisplayCapabilities1, specifying user interface display capabilities.
 #
-# + DispTp     - Type of user interface.
-# + NbOfLines  - Number of display lines.
-# + LineWidth  - Width of the display lines.
+# + DispTp - Type of user interface.
+# + NbOfLines - Number of display lines.
+# + LineWidth - Width of the display lines.
 public type DisplayCapabilities1 record {|
     UserInterface2Code DispTp;
     Max3NumericText NbOfLines;
@@ -1503,7 +1503,7 @@ public type DisplayCapabilities1 record {|
 
 # Defines the structure for EntryDetails13, containing details of batch and transaction information.
 #
-# + Btch   - Batch information.
+# + Btch - Batch information.
 # + TxDtls - List of transaction details.
 public type EntryDetails13 record {|
     BatchInformation2 Btch?;
@@ -1512,33 +1512,33 @@ public type EntryDetails13 record {|
 
 # Defines the structure for EntryTransaction14, representing details of a single entry transaction.
 #
-# + Refs       - Transaction references.
-# + Amt        - Transaction amount.
-# + CdtDbtInd  - Credit or debit indicator.
-# + AmtDtls    - Details of the amount and currency exchange.
-# + Avlbty     - Availability of cash.
-# + BkTxCd     - Bank transaction code structure.
-# + Chrgs      - Charges associated with the transaction.
-# + Intrst     - Interest information.
-# + RltdPties  - Related transaction parties.
-# + RltdAgts   - Related transaction agents.
-# + LclInstrm  - Local instrument choice.
-# + PmtTpInf   - Payment type information.
-# + Purp       - Purpose of the transaction.
+# + Refs - Transaction references.
+# + Amt - Transaction amount.
+# + CdtDbtInd - Credit or debit indicator.
+# + AmtDtls - Details of the amount and currency exchange.
+# + Avlbty - Availability of cash.
+# + BkTxCd - Bank transaction code structure.
+# + Chrgs - Charges associated with the transaction.
+# + Intrst - Interest information.
+# + RltdPties - Related transaction parties.
+# + RltdAgts - Related transaction agents.
+# + LclInstrm - Local instrument choice.
+# + PmtTpInf - Payment type information.
+# + Purp - Purpose of the transaction.
 # + RltdRmtInf - Related remittance information (up to 10 instances).
-# + RmtInf     - Remittance information.
-# + RltdDts    - Related transaction dates.
-# + RltdPric   - Related transaction price.
-# + RltdQties  - Related transaction quantities.
-# + FinInstrmId- Financial instrument identification.
-# + Tax        - Tax data.
-# + RtrInf     - Payment return reason information.
-# + CorpActn   - Corporate action details.
-# + SfkpgAcct  - Securities safekeeping account.
-# + CshDpst    - Cash deposit information.
-# + CardTx     - Card transaction information.
+# + RmtInf - Remittance information.
+# + RltdDts - Related transaction dates.
+# + RltdPric - Related transaction price.
+# + RltdQties - Related transaction quantities.
+# + FinInstrmId - Financial instrument identification.
+# + Tax - Tax data.
+# + RtrInf - Payment return reason information.
+# + CorpActn - Corporate action details.
+# + SfkpgAcct - Securities safekeeping account.
+# + CshDpst - Cash deposit information.
+# + CardTx - Card transaction information.
 # + AddtlTxInf - Additional transaction information.
-# + SplmtryData- Supplementary data.
+# + SplmtryData - Supplementary data.
 public type EntryTransaction14 record {|
     TransactionReferences6 Refs?;
     ActiveOrHistoricCurrencyAndAmount Amt?;
@@ -1617,7 +1617,7 @@ public type ExternalTechnicalInputChannel1Code string;
 # Defines the structure for FinancialInstrumentQuantity1Choice, offering a choice between different quantity types for a financial instrument.
 #
 # + Unit - Unit quantity.
-# + FaceAmt  - Face amount.
+# + FaceAmt - Face amount.
 # + AmtsdVal - Amortized value.
 public type FinancialInstrumentQuantity1Choice record {|
     DecimalNumber Unit?;
@@ -1636,9 +1636,9 @@ public type FromToAmountRange1 record {|
 
 # Defines the structure for GenericIdentification1, representing a generic identifier with an optional scheme name and issuer.
 #
-# + Id      - Identifier.
+# + Id - Identifier.
 # + SchmeNm - Scheme name.
-# + Issr    - Issuer.
+# + Issr - Issuer.
 public type GenericIdentification1 record {|
     Max35Text Id?;
     Max35Text SchmeNm?;
@@ -1647,7 +1647,7 @@ public type GenericIdentification1 record {|
 
 # Defines the structure for GenericIdentification3, representing a generic identifier with an issuer.
 #
-# + Id   - Identifier.
+# + Id - Identifier.
 # + Issr - Issuer.
 public type GenericIdentification3 record {|
     Max35Text Id?;
@@ -1656,9 +1656,9 @@ public type GenericIdentification3 record {|
 
 # Defines the structure for GenericIdentification32, representing a generic identifier with a party type, issuer, and short name.
 #
-# + Id     - Identifier.
-# + Tp     - Party type.
-# + Issr   - Issuer.
+# + Id - Identifier.
+# + Tp - Party type.
+# + Issr - Issuer.
 # + ShrtNm - Short name.
 public type GenericIdentification32 record {|
     Max35Text Id;
@@ -1669,12 +1669,12 @@ public type GenericIdentification32 record {|
 
 # Defines the structure for GroupHeader116, representing the header of a message with creation date-time, message recipient, and other optional elements.
 #
-# + MsgId        - Message identifier.
-# + CreDtTm      - Creation date-time.
-# + MsgRcpt      - Message recipient.
-# + MsgPgntn     - Message pagination details.
-# + OrgnlBizQry  - Original business query details.
-# + AddtlInf     - Additional information.
+# + MsgId - Message identifier.
+# + CreDtTm - Creation date-time.
+# + MsgRcpt - Message recipient.
+# + MsgPgntn - Message pagination details.
+# + OrgnlBizQry - Original business query details.
+# + AddtlInf - Additional information.
 public type GroupHeader116 record {|
     Max35Text MsgId;
     ISODateTime CreDtTm;
@@ -1695,7 +1695,7 @@ public type ISOYearMonth string;
 
 # Defines the structure for IdentificationSource3Choice, offering a choice between an external code or a proprietary identifier.
 #
-# + Cd    - External code.
+# + Cd - External code.
 # + Prtry - Proprietary identifier.
 public type IdentificationSource3Choice record {|
     ExternalFinancialInstrumentIdentificationType1Code Cd?;
@@ -1704,11 +1704,11 @@ public type IdentificationSource3Choice record {|
 
 # Defines the structure for ImpliedCurrencyAmountRange1Choice, offering a choice between different amount range types.
 #
-# + FrAmt   - From amount boundary.
-# + ToAmt   - To amount boundary.
+# + FrAmt - From amount boundary.
+# + ToAmt - To amount boundary.
 # + FrToAmt - From-to amount range.
-# + EQAmt   - Equal amount.
-# + NEQAmt  - Not equal amount.
+# + EQAmt - Equal amount.
+# + NEQAmt - Not equal amount.
 public type ImpliedCurrencyAmountRange1Choice record {|
     AmountRangeBoundary1 FrAmt?;
     AmountRangeBoundary1 ToAmt?;
@@ -1722,13 +1722,13 @@ public type ImpliedCurrencyAndAmount decimal;
 
 # Defines the structure for InterestRecord2, representing interest details including amount, type, and tax charges.
 #
-# + Amt     - Interest amount.
-# + CdtDbtInd- Credit or debit indicator.
-# + Tp      - Type of interest.
-# + Rate    - Interest rate.
-# + FrToDt  - From-to date-time range for interest.
-# + Rsn     - Reason for interest.
-# + Tax     - Tax charges associated with the interest.
+# + Amt - Interest amount.
+# + CdtDbtInd - Credit or debit indicator.
+# + Tp - Type of interest.
+# + Rate - Interest rate.
+# + FrToDt - From-to date-time range for interest.
+# + Rsn - Reason for interest.
+# + Tax - Tax charges associated with the interest.
 public type InterestRecord2 record {|
     ActiveOrHistoricCurrencyAndAmount Amt;
     CreditDebitCode CdtDbtInd;
@@ -1741,7 +1741,7 @@ public type InterestRecord2 record {|
 
 # Defines the structure for InterestType1Choice, offering a choice between an interest type code and a proprietary identifier.
 #
-# + Cd    - Interest type code.
+# + Cd - Interest type code.
 # + Prtry - Proprietary interest type.
 public type InterestType1Choice record {|
     InterestType1Code Cd?;
@@ -1754,7 +1754,7 @@ public enum InterestType1Code {
 
 # Defines the structure for LocalInstrument2Choice, offering a choice between an external local instrument code and a proprietary identifier.
 #
-# + Cd    - External local instrument code.
+# + Cd - External local instrument code.
 # + Prtry - Proprietary local instrument identifier.
 public type LocalInstrument2Choice record {|
     ExternalLocalInstrument1Code Cd?;
@@ -1785,7 +1785,7 @@ public type Max5NumericText string;
 # Defines the structure for MessageIdentification2, containing identifiers for a message name and message.
 #
 # + MsgNmId - Message name identifier.
-# + MsgId   - Message identifier.
+# + MsgId - Message identifier.
 public type MessageIdentification2 record {|
     Max35Text MsgNmId?;
     Max35Text MsgId?;
@@ -1806,7 +1806,7 @@ public type NonNegativeDecimalNumber decimal;
 # Defines the structure for NumberAndSumOfTransactions1, containing the number of entries and their sum.
 #
 # + NbOfNtries - Number of entries.
-# + Sum        - Sum of the entries.
+# + Sum - Sum of the entries.
 public type NumberAndSumOfTransactions1 record {|
     Max15NumericText NbOfNtries?;
     DecimalNumber Sum?;
@@ -1814,9 +1814,9 @@ public type NumberAndSumOfTransactions1 record {|
 
 # Defines the structure for NumberAndSumOfTransactions4, containing the number of entries, their sum, and the total net entry.
 #
-# + NbOfNtries  - Number of entries.
-# + Sum         - Sum of the entries.
-# + TtlNetNtry  - Total net entry amount and direction.
+# + NbOfNtries - Number of entries.
+# + Sum - Sum of the entries.
+# + TtlNetNtry - Total net entry amount and direction.
 public type NumberAndSumOfTransactions4 record {|
     Max15NumericText NbOfNtries?;
     DecimalNumber Sum?;
@@ -1829,7 +1829,7 @@ public enum OnLineCapability1Code {
 
 # Defines the structure for OriginalAndCurrentQuantities1, representing the original and current quantities of a financial instrument.
 #
-# + FaceAmt  - Original face amount.
+# + FaceAmt - Original face amount.
 # + AmtsdVal - Current amortized value.
 public type OriginalAndCurrentQuantities1 record {|
     ImpliedCurrencyAndAmount FaceAmt;
@@ -1838,9 +1838,9 @@ public type OriginalAndCurrentQuantities1 record {|
 
 # Defines the structure for OriginalBusinessQuery1, containing information about the original business query.
 #
-# + MsgId    - Message identifier.
-# + MsgNmId  - Message name identifier.
-# + CreDtTm  - Creation date-time.
+# + MsgId - Message identifier.
+# + MsgNmId - Message name identifier.
+# + CreDtTm - Creation date-time.
 public type OriginalBusinessQuery1 record {|
     Max35Text MsgId;
     Max35Text MsgNmId?;
@@ -1849,9 +1849,9 @@ public type OriginalBusinessQuery1 record {|
 
 # Defines the structure for OtherIdentification1, representing other identification information including an optional suffix and identification source.
 #
-# + Id   - Identifier.
-# + Sfx  - Suffix.
-# + Tp   - Identification source.
+# + Id - Identifier.
+# + Sfx - Suffix.
+# + Tp - Identification source.
 public type OtherIdentification1 record {|
     Max35Text Id;
     Max16Text Sfx?;
@@ -1864,7 +1864,7 @@ public enum POIComponentType1Code {
 
 # Defines the structure for Pagination1, representing pagination information for a message.
 #
-# + PgNb      - Page number.
+# + PgNb - Page number.
 # + LastPgInd - Indicator of whether this is the last page.
 public type Pagination1 record {|
     Max5NumericText PgNb;
@@ -1881,10 +1881,10 @@ public enum PartyType4Code {
 
 # Defines the structure for PaymentCard4, representing details of a payment card.
 #
-# + PlainCardData   - Plain card data.
-# + CardCtryCd      - Card country code.
-# + CardBrnd        - Card brand.
-# + AddtlCardData   - Additional card data.
+# + PlainCardData - Plain card data.
+# + CardCtryCd - Card country code.
+# + CardBrnd - Card brand.
+# + AddtlCardData - Additional card data.
 public type PaymentCard4 record {|
     PlainCardData1 PlainCardData?;
     Exact3NumericText CardCtryCd?;
@@ -1894,17 +1894,17 @@ public type PaymentCard4 record {|
 
 # Defines the structure for PaymentContext3, representing the context of a payment transaction, including details about the presence of the cardholder, attendance, and authentication.
 #
-# + CardPres         - Indicates if the card was present.
-# + CrdhldrPres      - Indicates if the cardholder was present.
-# + OnLineCntxt      - Indicates if the transaction was online.
-# + AttndncCntxt     - Attendance context.
-# + TxEnvt           - Transaction environment.
-# + TxChanl          - Transaction channel.
-# + AttndntMsgCpbl   - Indicates if the attendant can send messages.
-# + AttndntLang      - Attendant language.
-# + CardDataNtryMd   - Card data entry mode.
-# + FllbckInd        - Indicates if fallback mode was used.
-# + AuthntcnMtd      - Authentication method.
+# + CardPres - Indicates if the card was present.
+# + CrdhldrPres - Indicates if the cardholder was present.
+# + OnLineCntxt - Indicates if the transaction was online.
+# + AttndncCntxt - Attendance context.
+# + TxEnvt - Transaction environment.
+# + TxChanl - Transaction channel.
+# + AttndntMsgCpbl - Indicates if the attendant can send messages.
+# + AttndntLang - Attendant language.
+# + CardDataNtryMd - Card data entry mode.
+# + FllbckInd - Indicates if fallback mode was used.
+# + AuthntcnMtd - Authentication method.
 public type PaymentContext3 record {|
     TrueFalseIndicator CardPres?;
     TrueFalseIndicator CrdhldrPres?;
@@ -1922,9 +1922,9 @@ public type PaymentContext3 record {|
 # Defines the structure for PaymentReturnReason8, representing the reason for a returned payment.
 #
 # + OrgnlBkTxCd - Original bank transaction code.
-# + Orgtr       - Originator.
-# + Rsn         - Return reason.
-# + AddtlInf    - Additional information about the return.
+# + Orgtr - Originator.
+# + Rsn - Return reason.
+# + AddtlInf - Additional information about the return.
 public type PaymentReturnReason8 record {|
     BankTransactionCodeStructure4 OrgnlBkTxCd?;
     PartyIdentification272 Orgtr?;
@@ -1935,11 +1935,11 @@ public type PaymentReturnReason8 record {|
 # Defines the structure for PaymentTypeInformation27, representing payment type information including priority, clearing channel, service level, and category purpose.
 #
 # + InstrPrty - Instruction priority.
-# + ClrChanl  - Clearing channel.
-# + SvcLvl    - Service level.
+# + ClrChanl - Clearing channel.
+# + SvcLvl - Service level.
 # + LclInstrm - Local instrument.
-# + SeqTp     - Sequence type.
-# + CtgyPurp  - Category purpose.
+# + SeqTp - Sequence type.
+# + CtgyPurp - Category purpose.
 public type PaymentTypeInformation27 record {|
     Priority2Code InstrPrty?;
     ClearingChannel2Code ClrChanl?;
@@ -1951,13 +1951,13 @@ public type PaymentTypeInformation27 record {|
 
 # Defines the structure for PlainCardData1, representing the basic details of a payment card.
 #
-# + PAN       - Primary account number.
+# + PAN - Primary account number.
 # + CardSeqNb - Card sequence number.
-# + FctvDt    - Effective date.
-# + XpryDt    - Expiry date.
-# + SvcCd     - Service code.
-# + TrckData  - Track data.
-# + CardSctyCd- Card security code.
+# + FctvDt - Effective date.
+# + XpryDt - Expiry date.
+# + SvcCd - Service code.
+# + TrckData - Track data.
+# + CardSctyCd - Card security code.
 public type PlainCardData1 record {|
     Min8Max28NumericText PAN;
     Min2Max3NumericText CardSeqNb?;
@@ -1970,11 +1970,11 @@ public type PlainCardData1 record {|
 
 # Defines the structure for PointOfInteraction1, representing a point of interaction device.
 #
-# + Id       - POI identification.
-# + SysNm    - System name.
-# + GrpId    - Group identifier.
+# + Id - POI identification.
+# + SysNm - System name.
+# + GrpId - Group identifier.
 # + Cpblties - POI capabilities.
-# + Cmpnt    - POI components.
+# + Cmpnt - POI components.
 public type PointOfInteraction1 record {|
     GenericIdentification32 Id;
     Max70Text SysNm?;
@@ -1985,11 +1985,11 @@ public type PointOfInteraction1 record {|
 
 # Defines the structure for PointOfInteractionCapabilities1, representing the capabilities of a point of interaction device.
 #
-# + CardRdngCpblties      - Card reading capabilities.
+# + CardRdngCpblties - Card reading capabilities.
 # + CrdhldrVrfctnCpblties - Cardholder verification capabilities.
-# + OnLineCpblties        - Online capabilities.
-# + DispCpblties          - Display capabilities.
-# + PrtLineWidth          - Printer line width.
+# + OnLineCpblties - Online capabilities.
+# + DispCpblties - Display capabilities.
+# + PrtLineWidth - Printer line width.
 public type PointOfInteractionCapabilities1 record {|
     CardDataReading1Code[] CardRdngCpblties?;
     CardholderVerificationCapability1Code[] CrdhldrVrfctnCpblties?;
@@ -2001,11 +2001,11 @@ public type PointOfInteractionCapabilities1 record {|
 # Defines the structure for PointOfInteractionComponent1, representing a component of a point of interaction device.
 #
 # + POICmpntTp - Component type.
-# + ManfctrId  - Manufacturer identifier.
-# + Mdl        - Model.
-# + VrsnNb     - Version number.
-# + SrlNb      - Serial number.
-# + ApprvlNb   - Approval numbers.
+# + ManfctrId - Manufacturer identifier.
+# + Mdl - Model.
+# + VrsnNb - Version number.
+# + SrlNb - Serial number.
+# + ApprvlNb - Approval numbers.
 public type PointOfInteractionComponent1 record {|
     POIComponentType1Code POICmpntTp;
     Max35Text ManfctrId?;
@@ -2020,7 +2020,7 @@ public type PositiveNumber decimal;
 
 # Defines the structure for Price7, representing a price in a financial transaction.
 #
-# + Tp  - Type of price (yielded or value type).
+# + Tp - Type of price (yielded or value type).
 # + Val - Price value (rate or amount).
 public type Price7 record {|
     YieldedOrValueType1Choice Tp;
@@ -2030,7 +2030,7 @@ public type Price7 record {|
 # Defines the structure for PriceRateOrAmount3Choice, offering a choice between a percentage rate and a currency amount.
 #
 # + Rate - Percentage rate.
-# + Amt  - Currency amount.
+# + Amt - Currency amount.
 public type PriceRateOrAmount3Choice record {|
     PercentageRate Rate?;
     ActiveOrHistoricCurrencyAnd13DecimalAmount Amt?;
@@ -2046,12 +2046,12 @@ public enum Priority2Code {
 
 # Defines the structure for Product2, representing a product including its code, unit of measure, and price.
 #
-# + PdctCd       - Product code.
-# + UnitOfMeasr  - Unit of measure.
-# + PdctQty      - Product quantity.
-# + UnitPric     - Unit price.
-# + PdctAmt      - Total product amount.
-# + TaxTp        - Tax type.
+# + PdctCd - Product code.
+# + UnitOfMeasr - Unit of measure.
+# + PdctQty - Product quantity.
+# + UnitPric - Unit price.
+# + PdctAmt - Total product amount.
+# + TaxTp - Tax type.
 # + AddtlPdctInf - Additional product information.
 public type Product2 record {|
     Max70Text PdctCd;
@@ -2065,7 +2065,7 @@ public type Product2 record {|
 
 # Defines the structure for ProprietaryAgent5, representing a proprietary agent and its type.
 #
-# + Tp  - Type of agent.
+# + Tp - Type of agent.
 # + Agt - Branch and financial institution identification of the agent.
 public type ProprietaryAgent5 record {|
     Max35Text Tp;
@@ -2074,8 +2074,8 @@ public type ProprietaryAgent5 record {|
 
 # Defines the structure for ProprietaryBankTransactionCodeStructure1, representing a proprietary bank transaction code.
 #
-# + Cd    - Transaction code.
-# + Issr  - Code issuer.
+# + Cd - Transaction code.
+# + Issr - Code issuer.
 public type ProprietaryBankTransactionCodeStructure1 record {|
     Max35Text Cd;
     Max35Text Issr?;
@@ -2083,8 +2083,8 @@ public type ProprietaryBankTransactionCodeStructure1 record {|
 
 # Defines the structure for ProprietaryDate3, representing a proprietary date.
 #
-# + Tp  - Date type.
-# + Dt  - Date value.
+# + Tp - Date type.
+# + Dt - Date value.
 public type ProprietaryDate3 record {|
     Max35Text Tp;
     DateAndDateTime2Choice Dt;
@@ -2092,7 +2092,7 @@ public type ProprietaryDate3 record {|
 
 # Defines the structure for ProprietaryParty6, representing a proprietary party including its type and party details.
 #
-# + Tp  - Party type.
+# + Tp - Party type.
 # + Pty - Party details.
 public type ProprietaryParty6 record {|
     Max35Text Tp;
@@ -2101,7 +2101,7 @@ public type ProprietaryParty6 record {|
 
 # Defines the structure for ProprietaryPrice2, representing a proprietary price.
 #
-# + Tp   - Price type.
+# + Tp - Price type.
 # + Pric - Price amount.
 public type ProprietaryPrice2 record {|
     Max35Text Tp;
@@ -2110,7 +2110,7 @@ public type ProprietaryPrice2 record {|
 
 # Defines the structure for ProprietaryQuantity1, representing a proprietary quantity.
 #
-# + Tp  - Quantity type.
+# + Tp - Quantity type.
 # + Qty - Quantity value.
 public type ProprietaryQuantity1 record {|
     Max35Text Tp;
@@ -2119,7 +2119,7 @@ public type ProprietaryQuantity1 record {|
 
 # Defines the structure for ProprietaryReference1, representing a proprietary reference.
 #
-# + Tp  - Reference type.
+# + Tp - Reference type.
 # + Ref - Reference value.
 public type ProprietaryReference1 record {|
     Max35Text Tp;
@@ -2128,8 +2128,8 @@ public type ProprietaryReference1 record {|
 
 # Defines the structure for Rate4, representing an interest rate or fee rate.
 #
-# + Tp        - Rate type.
-# + VldtyRg   - Validity range for the rate.
+# + Tp - Rate type.
+# + VldtyRg - Validity range for the rate.
 public type Rate4 record {|
     RateType4Choice Tp;
     ActiveOrHistoricCurrencyAndAmountRange2 VldtyRg?;
@@ -2137,8 +2137,8 @@ public type Rate4 record {|
 
 # Defines the structure for RateType4Choice, offering a choice between a percentage rate and an alternative rate type.
 #
-# + Pctg  - Percentage rate.
-# + Othr  - Other rate type.
+# + Pctg - Percentage rate.
+# + Othr - Other rate type.
 public type RateType4Choice record {|
     PercentageRate Pctg?;
     Max35Text Othr?;
@@ -2146,25 +2146,25 @@ public type RateType4Choice record {|
 
 # Defines the structure for ReportEntry14, representing a report entry with various details including amount, status, and charges.
 #
-# + NtryRef         - Entry reference.
-# + Amt             - Entry amount.
-# + CdtDbtInd       - Credit or debit indicator.
-# + RvslInd         - Reversal indicator.
-# + Sts             - Entry status.
-# + BookgDt         - Booking date.
-# + ValDt           - Value date.
-# + AcctSvcrRef     - Account servicer reference.
-# + Avlbty          - Cash availability details.
-# + BkTxCd          - Bank transaction code.
-# + ComssnWvrInd    - Commission waiver indicator.
-# + AddtlInfInd     - Additional information indicator.
-# + AmtDtls         - Amount and currency exchange details.
-# + Chrgs           - Charges applied to the entry.
-# + TechInptChanl   - Technical input channel used.
-# + Intrst          - Interest details.
-# + CardTx          - Card transaction details.
-# + NtryDtls        - Entry details.
-# + AddtlNtryInf    - Additional entry information.
+# + NtryRef - Entry reference.
+# + Amt - Entry amount.
+# + CdtDbtInd - Credit or debit indicator.
+# + RvslInd - Reversal indicator.
+# + Sts - Entry status.
+# + BookgDt - Booking date.
+# + ValDt - Value date.
+# + AcctSvcrRef - Account servicer reference.
+# + Avlbty - Cash availability details.
+# + BkTxCd - Bank transaction code.
+# + ComssnWvrInd - Commission waiver indicator.
+# + AddtlInfInd - Additional information indicator.
+# + AmtDtls - Amount and currency exchange details.
+# + Chrgs - Charges applied to the entry.
+# + TechInptChanl - Technical input channel used.
+# + Intrst - Interest details.
+# + CardTx - Card transaction details.
+# + NtryDtls - Entry details.
+# + AddtlNtryInf - Additional entry information.
 public type ReportEntry14 record {|
     Max35Text NtryRef?;
     ActiveOrHistoricCurrencyAndAmount Amt;
@@ -2189,7 +2189,7 @@ public type ReportEntry14 record {|
 
 # Defines the structure for ReportingSource1Choice, offering a choice between an external reporting source code and a proprietary source.
 #
-# + Cd    - External reporting source code.
+# + Cd - External reporting source code.
 # + Prtry - Proprietary source.
 public type ReportingSource1Choice record {|
     ExternalReportingSource1Code Cd?;
@@ -2198,7 +2198,7 @@ public type ReportingSource1Choice record {|
 
 # Defines the structure for ReturnReason5Choice, offering a choice between an external return reason code and a proprietary reason.
 #
-# + Cd    - External return reason code.
+# + Cd - External return reason code.
 # + Prtry - Proprietary reason.
 public type ReturnReason5Choice record {|
     ExternalReturnReason1Code Cd?;
@@ -2207,9 +2207,9 @@ public type ReturnReason5Choice record {|
 
 # Defines the structure for SecuritiesAccount19, representing a securities account including its identifier, type, and name.
 #
-# + Id   - Account identifier.
-# + Tp   - Account type.
-# + Nm   - Account name.
+# + Id - Account identifier.
+# + Tp - Account type.
+# + Nm - Account name.
 public type SecuritiesAccount19 record {|
     Max35Text Id;
     GenericIdentification30 Tp?;
@@ -2218,9 +2218,9 @@ public type SecuritiesAccount19 record {|
 
 # Defines the structure for SecurityIdentification19, representing security identification details including ISIN and other identifiers.
 #
-# + ISIN   - ISIN identifier.
+# + ISIN - ISIN identifier.
 # + OthrId - Other security identifiers.
-# + Desc   - Security description.
+# + Desc - Security description.
 public type SecurityIdentification19 record {|
     ISINOct2015Identifier ISIN?;
     OtherIdentification1[] OthrId?;
@@ -2233,7 +2233,7 @@ public enum SequenceType3Code {
 
 # Defines the structure for ServiceLevel8Choice, offering a choice between an external service level code and a proprietary service level.
 #
-# + Cd    - External service level code.
+# + Cd - External service level code.
 # + Prtry - Proprietary service level.
 public type ServiceLevel8Choice record {|
     ExternalServiceLevel1Code Cd?;
@@ -2242,9 +2242,9 @@ public type ServiceLevel8Choice record {|
 
 # Defines the structure for TaxCharges2, representing tax charges applied to a transaction.
 #
-# + Id    - Tax identifier.
-# + Rate  - Tax rate.
-# + Amt   - Tax amount.
+# + Id - Tax identifier.
+# + Rate - Tax rate.
+# + Amt - Tax amount.
 public type TaxCharges2 record {|
     Max35Text Id?;
     PercentageRate Rate?;
@@ -2253,7 +2253,7 @@ public type TaxCharges2 record {|
 
 # Defines the structure for TechnicalInputChannel1Choice, offering a choice between an external technical input channel and a proprietary channel.
 #
-# + Cd    - External technical input channel code.
+# + Cd - External technical input channel code.
 # + Prtry - Proprietary input channel.
 public type TechnicalInputChannel1Choice record {|
     ExternalTechnicalInputChannel1Code Cd?;
@@ -2262,10 +2262,10 @@ public type TechnicalInputChannel1Choice record {|
 
 # Defines the structure for TotalTransactions6, representing totals for transactions including credit and debit entries.
 #
-# + TtlNtries            - Total entries.
-# + TtlCdtNtries         - Total credit entries.
-# + TtlDbtNtries         - Total debit entries.
-# + TtlNtriesPerBkTxCd   - Totals per bank transaction code.
+# + TtlNtries - Total entries.
+# + TtlCdtNtries - Total credit entries.
+# + TtlDbtNtries - Total debit entries.
+# + TtlNtriesPerBkTxCd - Totals per bank transaction code.
 public type TotalTransactions6 record {|
     NumberAndSumOfTransactions4 TtlNtries?;
     NumberAndSumOfTransactions1 TtlCdtNtries?;
@@ -2275,15 +2275,15 @@ public type TotalTransactions6 record {|
 
 # Defines the structure for TotalsPerBankTransactionCode5, representing totals for entries per bank transaction code.
 #
-# + NbOfNtries   - Number of entries.
-# + Sum          - Sum of the entries.
-# + TtlNetNtry   - Total net entry.
-# + CdtNtries    - Credit entries.
-# + DbtNtries    - Debit entries.
-# + FcstInd      - Forecast indicator.
-# + BkTxCd       - Bank transaction code.
-# + Avlbty       - Availability information.
-# + Dt           - Date of the entries.
+# + NbOfNtries - Number of entries.
+# + Sum - Sum of the entries.
+# + TtlNetNtry - Total net entry.
+# + CdtNtries - Credit entries.
+# + DbtNtries - Debit entries.
+# + FcstInd - Forecast indicator.
+# + BkTxCd - Bank transaction code.
+# + Avlbty - Availability information.
+# + Dt - Date of the entries.
 public type TotalsPerBankTransactionCode5 record {|
     Max15NumericText NbOfNtries?;
     DecimalNumber Sum?;
@@ -2298,7 +2298,7 @@ public type TotalsPerBankTransactionCode5 record {|
 
 # Defines the structure for TrackData1, representing track data on a payment card.
 #
-# + TrckNb  - Track number.
+# + TrckNb - Track number.
 # + TrckVal - Track value.
 public type TrackData1 record {|
     Exact1NumericText TrckNb?;
@@ -2307,18 +2307,18 @@ public type TrackData1 record {|
 
 # Defines the structure for TransactionAgents6, representing agents involved in a transaction including debtor, creditor, and intermediaries.
 #
-# + InstgAgt    - Instructing agent.
-# + InstdAgt    - Instructed agent.
-# + DbtrAgt     - Debtor agent.
-# + CdtrAgt     - Creditor agent.
-# + IntrmyAgt1  - First intermediary agent.
-# + IntrmyAgt2  - Second intermediary agent.
-# + IntrmyAgt3  - Third intermediary agent.
-# + RcvgAgt     - Receiving agent.
-# + DlvrgAgt    - Delivering agent.
-# + IssgAgt     - Issuing agent.
-# + SttlmPlc    - Settlement place.
-# + Prtry       - Proprietary agents.
+# + InstgAgt - Instructing agent.
+# + InstdAgt - Instructed agent.
+# + DbtrAgt - Debtor agent.
+# + CdtrAgt - Creditor agent.
+# + IntrmyAgt1 - First intermediary agent.
+# + IntrmyAgt2 - Second intermediary agent.
+# + IntrmyAgt3 - Third intermediary agent.
+# + RcvgAgt - Receiving agent.
+# + DlvrgAgt - Delivering agent.
+# + IssgAgt - Issuing agent.
+# + SttlmPlc - Settlement place.
+# + Prtry - Proprietary agents.
 public type TransactionAgents6 record {|
     BranchAndFinancialInstitutionIdentification8 InstgAgt?;
     BranchAndFinancialInstitutionIdentification8 InstdAgt?;
@@ -2966,7 +2966,6 @@ public type OriginalGroupInformation29 record {|
     Max35Text OrgnlMsgNmId;
     ISODateTime OrgnlCreDtTm?;
 |};
-
 
 # Defines the structure for MandateRelatedData3Choice, representing choices for mandate-related data.
 #

--- a/iso20022/modules/payments_clearing_and_settlement/pacs.002.001.14.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/pacs.002.001.14.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Pacs002Document1.
 public type Pacs002Document1 Pacs002Document;
@@ -20,6 +21,12 @@ public type Pacs002Document1 Pacs002Document;
 # Defines the structure for Pacs002Document, which encapsulates the payment status report details.
 #
 # + FIToFIPmtStsRpt - Payment status report information
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:pacs.002.001.14"
+}
 public type Pacs002Document record {|
     FIToFIPaymentStatusReportV14 FIToFIPmtStsRpt;
 |};

--- a/iso20022/modules/payments_clearing_and_settlement/pacs.003.001.11.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/pacs.003.001.11.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Pacs003Document1.
 public type Pac003Document1 Pacs003Document;
@@ -97,6 +98,12 @@ public type DirectDebitTransactionInformation31 record {|
 # Defines the structure for Pacs003Document, which encapsulates the customer direct debit transaction details.
 #
 # + FIToFICstmrDrctDbt - Customer direct debit transaction information
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:pacs.003.001.11"
+}
 public type Pacs003Document record {|
     FIToFICustomerDirectDebitV11 FIToFICstmrDrctDbt;
 |};

--- a/iso20022/modules/payments_clearing_and_settlement/pacs.008.001.12.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/pacs.008.001.12.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Pacs008Document1.
 public type Pacs008Document1 Pacs008Document;
@@ -119,6 +120,12 @@ public type CreditTransferTransaction64 record {|
 # Defines the structure for Pacs008Document, which encapsulates the customer credit transfer transaction details.
 #
 # + FIToFICstmrCdtTrf - Customer credit transfer transaction information
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:pacs.008.001.12"
+}
 public type Pacs008Document record {|
     FIToFICustomerCreditTransferV12 FIToFICstmrCdtTrf;
 |};

--- a/iso20022/modules/payments_clearing_and_settlement/pacs.009.001.11.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/pacs.009.001.11.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Pacs009Document1.
 public type Pac009Document1 Pacs009Document;
@@ -162,6 +163,12 @@ public type CreditTransferTransaction63 record {|
 # Defines the structure for Pacs009Document, which encapsulates the financial institution credit transfer transaction information.
 #
 # + FICdtTrf - Financial institution credit transfer transaction information
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:pacs.009.001.11"
+}
 public type Pacs009Document record {|
     FinancialInstitutionCreditTransferV11 FICdtTrf;
 |};

--- a/iso20022/modules/payments_clearing_and_settlement/pacs.010.001.06.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/pacs.010.001.06.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/data.xmldata;
 
 # Defines the structure for the Pacs010Document1
 public type Pacs010Document1 Pacs010Document;
@@ -104,6 +105,12 @@ public type DirectDebitTransactionInformation33 record {|
 # Defines the structure for Pacs010Document, which encapsulates the financial institution direct debit transaction information.
 #
 # + FIDrctDbt - Financial institution direct debit transaction information
+@xmldata:Name {
+    value: "Document"
+}
+@xmldata:Namespace {
+    uri: "urn:iso:std:iso:20022:tech:xsd:pacs.010.001.06"
+}
 public type Pacs010Document record {|
     FinancialInstitutionDirectDebitV06 FIDrctDbt;
 |};


### PR DESCRIPTION
## Purpose
Enhance the document records in the library by including the appropriate name and namespace attributes. These additions are essential to ensure that the generated XML or JSON documents align with the ISO 20022 standards, which mandate specific naming conventions and namespace structures for interoperability and compliance

## Goals
Provide valid ISO 20022 XML or JSON documents that can be seamlessly integrated into systems adhering to the ISO 20022 standards. By adding name and namespace attributes, the PR aims to improve compatibility and ensure that the library meets the requirements for financial messaging across various applications.