### PR TITLE
Remove Namespace To Allow Parsing XML With Custom Namespace Prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,32 +40,163 @@ The ISO 20022 library provides a comprehensive collection of ISO 20022 records, 
 
 - financial.iso20022.cash_management
 - financial.iso20022.payment_initiation
-- financial.iso20022.payments_clearing_and_settlement
+- financial.iso20022.payments_clearing_and_settlement 
 
 ## Usage
 
-### Step 1: Import the library
-
-Import the `ballerinax/financial.iso20022.payment_initiation` library.
+### Create new ISO 20022 documents and Convert to XML
 
 ```ballerina
-import ballerinax/financial.iso20022.payment_initiation as isorecord;
+import ballerinax/financial.iso20022.payments_clearing_and_settlement as isorecord;
+import ballerinax/financial.iso20022 as iso20022;
+import ballerina/io;
+
+public function main() returns error? {
+    isorecord:Pacs004Envelope envelope = {
+        // AppHdr is optional so documents can be created with or without AppHdr.
+        AppHdr:{
+            Fr:{FIId:{FinInstnId:{BICFI:"NDEAFIHHXXX"}}},
+            To:{FIId:{FinInstnId:{"BICFI":"ABNANL2AXXX"}}},
+            BizMsgIdr:"pacs4bizmsgidr02",
+            MsgDefIdr:"pacs.004.001.09",
+            BizSvc:"swift.cbprplus.02",
+            CreDt:"2020-08-03T12:13:41.960+00:00",
+            Rltd:[
+                {Fr:{FIId:{FinInstnId:{BICFI:"ABNANL2AXXX"}}},
+                To:{FIId:{FinInstnId:{BICFI:"NDEAFIHHXXX"}}},
+                BizMsgIdr:"pacs9bizmsgidr01",
+                MsgDefIdr:"pacs.009.001.08",
+                BizSvc:"swift.cbprplus.02",
+                CreDt:"2020-08-03T10:13:41.960+00:00"}]},
+        Document:{
+            PmtRtr:{
+                GrpHdr:{
+                    MsgId:"pacs4bizmsgidr02",
+                    CreDtTm:"2020-08-03T12:13:41.960+00:00",
+                    NbOfTxs:"1",
+                    SttlmInf:{SttlmMtd:"INGA"}},
+                    TxInf:[
+                        {OrgnlGrpInf:{OrgnlMsgId:"pacs9bizmsgidr01",OrgnlMsgNmId:"pacs.009.001.08"},
+                        OrgnlInstrId:"pacs9bizmsgidr01",OrgnlEndToEndId:"pacs009EndToEndId-001",OrgnlUETR:"dab3b64f-092b-4839-b7e9-8f438af50961",OrgnlIntrBkSttlmAmt:{content:654489.98,Ccy:"EUR"},OrgnlIntrBkSttlmDt:"2020-08-03",RtrdIntrBkSttlmAmt:{content:654489.98,Ccy:"EUR"},IntrBkSttlmDt:"2020-08-03",ChrgBr:"SHAR",InstgAgt:{FinInstnId:{BICFI:"NDEAFIHHXXX"}},InstdAgt:{FinInstnId:{BICFI:"ABNANL2AXXX"}},RtrChain:{Dbtr:{Agt:{FinInstnId:{BICFI:"NDEAFIHHXXX"}}},CdtrAgt:{FinInstnId:{BICFI:"ABNANL2AXXX"}},Cdtr:{Agt:{FinInstnId:{BICFI:"RBOSGB2LXXX"}}}},RtrRsnInf:[{Rsn:{Cd:"AC04"}}]}]}}
+    };
+    io:println(iso20022:toIso20022Xml(envelope));
+}
 ```
 
-### Step 2: Create new ISO 20022 documents based on requirement
+### Parse ISO 20022 XML to Corresponding ISO 20022 Record Type
 
 ```ballerina
-isorecord:Pain001Document document = {
-    CstmrCdtTrfInitn: {
-        GrpHdr: {
-            CreDtTm: time:utcToString(time:utcNow()), 
-            InitgPty: {}, 
-            NbOfTxs: "1", 
-            MsgId: uuid:createType4AsString().substring(0, 11)
-        }, 
-        PmtInf: []
-    }
-};
+import ballerinax/financial.iso20022.payments_clearing_and_settlement as isorecord;
+import ballerinax/financial.iso20022 as iso20022;
+import ballerina/io;
+
+public function main() returns error? {
+    xml newXml = xml `<Envelope xmlns="urn:swift:xsd:envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:swift:xsd:envelope \\be-file02\Group\Standards\Messaging\CBPR+Schemas\Feb24Schemas_Core\Translator_envelope_core.xsd">
+        <AppHdr xmlns="urn:iso:std:iso:20022:tech:xsd:head.001.001.04">
+            <Fr>
+                <FIId>
+                    <FinInstnId>
+                        <BICFI>NDEAFIHHXXX</BICFI>
+                    </FinInstnId>
+                </FIId>
+            </Fr>
+            <To>
+                <FIId>
+                    <FinInstnId>
+                        <BICFI>ABNANL2AXXX</BICFI>
+                    </FinInstnId>
+                </FIId>
+            </To>
+            <BizMsgIdr>pacs4bizmsgidr02</BizMsgIdr>
+            <MsgDefIdr>pacs.004.001.09</MsgDefIdr>
+            <BizSvc>swift.cbprplus.02</BizSvc>
+            <CreDt>2020-08-03T12:13:41.960+00:00</CreDt>
+            <Rltd>
+                <Fr>
+                    <FIId>
+                        <FinInstnId>
+                            <BICFI>ABNANL2AXXX</BICFI>
+                        </FinInstnId>
+                    </FIId>
+                </Fr>
+                <To>
+                    <FIId>
+                        <FinInstnId>
+                            <BICFI>NDEAFIHHXXX</BICFI>
+                        </FinInstnId>
+                    </FIId>
+                </To>
+                <BizMsgIdr>pacs9bizmsgidr01</BizMsgIdr>
+                <MsgDefIdr>pacs.009.001.08</MsgDefIdr>
+                <BizSvc>swift.cbprplus.02</BizSvc>
+                <CreDt>2020-08-03T10:13:41.960+00:00</CreDt>
+            </Rltd>
+        </AppHdr>
+        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:pacs.004.001.13">
+            <PmtRtr>
+                <GrpHdr>
+                    <MsgId>pacs4bizmsgidr02</MsgId>
+                    <CreDtTm>2020-08-03T12:13:41.960+00:00</CreDtTm>
+                    <NbOfTxs>1</NbOfTxs>
+                    <SttlmInf>
+                        <SttlmMtd>INGA</SttlmMtd>
+                    </SttlmInf>
+                </GrpHdr>
+                <TxInf>
+                    <OrgnlGrpInf>
+                        <OrgnlMsgId>pacs9bizmsgidr01</OrgnlMsgId>
+                        <OrgnlMsgNmId>pacs.009.001.08</OrgnlMsgNmId>
+                    </OrgnlGrpInf>
+                    <OrgnlInstrId>pacs9bizmsgidr01</OrgnlInstrId>
+                    <OrgnlEndToEndId>pacs009EndToEndId-001</OrgnlEndToEndId>
+                    <OrgnlUETR>dab3b64f-092b-4839-b7e9-8f438af50961</OrgnlUETR>
+                    <OrgnlIntrBkSttlmAmt Ccy="EUR">654489.98</OrgnlIntrBkSttlmAmt>
+                    <OrgnlIntrBkSttlmDt>2020-08-03</OrgnlIntrBkSttlmDt>
+                    <RtrdIntrBkSttlmAmt Ccy="EUR">654489.98</RtrdIntrBkSttlmAmt>
+                    <IntrBkSttlmDt>2020-08-03</IntrBkSttlmDt>
+                    <ChrgBr>SHAR</ChrgBr>
+                    <InstgAgt>
+                        <FinInstnId>
+                            <BICFI>NDEAFIHHXXX</BICFI>
+                        </FinInstnId>
+                    </InstgAgt>
+                    <InstdAgt>
+                        <FinInstnId>
+                            <BICFI>ABNANL2AXXX</BICFI>
+                        </FinInstnId>
+                    </InstdAgt>
+                    <RtrChain>
+                        <Dbtr>
+                            <Agt>
+                                <FinInstnId>
+                                    <BICFI>NDEAFIHHXXX</BICFI>
+                                </FinInstnId>
+                            </Agt>
+                        </Dbtr>
+                        <CdtrAgt>
+                            <FinInstnId>
+                                <BICFI>ABNANL2AXXX</BICFI>
+                            </FinInstnId>
+                        </CdtrAgt>
+                        <Cdtr>
+                            <Agt>
+                                <FinInstnId>
+                                    <BICFI>RBOSGB2LXXX</BICFI>
+                                </FinInstnId>
+                            </Agt>
+                        </Cdtr>
+                    </RtrChain>
+                    <RtrRsnInf>
+                        <Rsn>
+                            <Cd>AC04</Cd>
+                        </Rsn>
+                    </RtrRsnInf>
+                </TxInf>
+            </PmtRtr>
+        </Document>
+    </Envelope>`;
+    io:println(iso20022:fromIso20022(newXml, isorecord:Pacs004Envelope));
+}
 ```
 
 ## Report issues

--- a/iso20022/Ballerina.toml
+++ b/iso20022/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "financial.iso20022"
-version = "1.1.0"
+version = "1.2.0"
 distribution = "2201.10.1"
 authors=["Ballerina"]
 export=["financial.iso20022", "financial.iso20022.cash_management", "financial.iso20022.payment_initiation", "financial.iso20022.payments_clearing_and_settlement"]

--- a/iso20022/Dependencies.toml
+++ b/iso20022/Dependencies.toml
@@ -46,7 +46,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "financial.iso20022"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "data.xmldata"},
 	{org = "ballerinai", name = "observe"}

--- a/iso20022/Module.md
+++ b/iso20022/Module.md
@@ -44,36 +44,157 @@ The ISO 20022 library provides a comprehensive collection of ISO 20022 records, 
 
 ## Usage
 
-### Step 1: Import the library
-
-Import the `ballerinax/financial.iso20022.payment_initiation` library.
+### Create new ISO 20022 documents and Convert to XML
 
 ```ballerina
-import ballerinax/financial.iso20022.payment_initiation as isorecord;
+import ballerinax/financial.iso20022.payments_clearing_and_settlement as isorecord;
+import ballerinax/financial.iso20022 as iso20022;
+import ballerina/io;
+
+public function main() returns error? {
+    isorecord:Pacs004Envelope envelope = {
+        // AppHdr is optional so documents can be created with or without AppHdr.
+        AppHdr:{
+            Fr:{FIId:{FinInstnId:{BICFI:"NDEAFIHHXXX"}}},
+            To:{FIId:{FinInstnId:{"BICFI":"ABNANL2AXXX"}}},
+            BizMsgIdr:"pacs4bizmsgidr02",
+            MsgDefIdr:"pacs.004.001.09",
+            BizSvc:"swift.cbprplus.02",
+            CreDt:"2020-08-03T12:13:41.960+00:00",
+            Rltd:[
+                {Fr:{FIId:{FinInstnId:{BICFI:"ABNANL2AXXX"}}},
+                To:{FIId:{FinInstnId:{BICFI:"NDEAFIHHXXX"}}},
+                BizMsgIdr:"pacs9bizmsgidr01",
+                MsgDefIdr:"pacs.009.001.08",
+                BizSvc:"swift.cbprplus.02",
+                CreDt:"2020-08-03T10:13:41.960+00:00"}]},
+        Document:{
+            PmtRtr:{
+                GrpHdr:{
+                    MsgId:"pacs4bizmsgidr02",
+                    CreDtTm:"2020-08-03T12:13:41.960+00:00",
+                    NbOfTxs:"1",
+                    SttlmInf:{SttlmMtd:"INGA"}},
+                    TxInf:[
+                        {OrgnlGrpInf:{OrgnlMsgId:"pacs9bizmsgidr01",OrgnlMsgNmId:"pacs.009.001.08"},
+                        OrgnlInstrId:"pacs9bizmsgidr01",OrgnlEndToEndId:"pacs009EndToEndId-001",OrgnlUETR:"dab3b64f-092b-4839-b7e9-8f438af50961",OrgnlIntrBkSttlmAmt:{content:654489.98,Ccy:"EUR"},OrgnlIntrBkSttlmDt:"2020-08-03",RtrdIntrBkSttlmAmt:{content:654489.98,Ccy:"EUR"},IntrBkSttlmDt:"2020-08-03",ChrgBr:"SHAR",InstgAgt:{FinInstnId:{BICFI:"NDEAFIHHXXX"}},InstdAgt:{FinInstnId:{BICFI:"ABNANL2AXXX"}},RtrChain:{Dbtr:{Agt:{FinInstnId:{BICFI:"NDEAFIHHXXX"}}},CdtrAgt:{FinInstnId:{BICFI:"ABNANL2AXXX"}},Cdtr:{Agt:{FinInstnId:{BICFI:"RBOSGB2LXXX"}}}},RtrRsnInf:[{Rsn:{Cd:"AC04"}}]}]}}
+    };
+    io:println(iso20022:toIso20022Xml(envelope));
+}
 ```
 
-### Step 2: Create new ISO 20022 documents based on requirement
+### Parse ISO 20022 XML to Corresponding ISO 20022 Record Type
 
 ```ballerina
-isorecord:Pain001Document document = {
-    CstmrCdtTrfInitn: {
-        GrpHdr: {
-            CreDtTm: time:utcToString(time:utcNow()), 
-            InitgPty: {}, 
-            NbOfTxs: "1", 
-            MsgId: uuid:createType4AsString().substring(0, 11)
-        }, 
-        PmtInf: []
-    }
-};
+import ballerinax/financial.iso20022.payments_clearing_and_settlement as isorecord;
+import ballerinax/financial.iso20022 as iso20022;
+import ballerina/io;
+
+public function main() returns error? {
+    xml newXml = xml `<Envelope xmlns="urn:swift:xsd:envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:swift:xsd:envelope \\be-file02\Group\Standards\Messaging\CBPR+Schemas\Feb24Schemas_Core\Translator_envelope_core.xsd">
+        <AppHdr xmlns="urn:iso:std:iso:20022:tech:xsd:head.001.001.04">
+            <Fr>
+                <FIId>
+                    <FinInstnId>
+                        <BICFI>NDEAFIHHXXX</BICFI>
+                    </FinInstnId>
+                </FIId>
+            </Fr>
+            <To>
+                <FIId>
+                    <FinInstnId>
+                        <BICFI>ABNANL2AXXX</BICFI>
+                    </FinInstnId>
+                </FIId>
+            </To>
+            <BizMsgIdr>pacs4bizmsgidr02</BizMsgIdr>
+            <MsgDefIdr>pacs.004.001.09</MsgDefIdr>
+            <BizSvc>swift.cbprplus.02</BizSvc>
+            <CreDt>2020-08-03T12:13:41.960+00:00</CreDt>
+            <Rltd>
+                <Fr>
+                    <FIId>
+                        <FinInstnId>
+                            <BICFI>ABNANL2AXXX</BICFI>
+                        </FinInstnId>
+                    </FIId>
+                </Fr>
+                <To>
+                    <FIId>
+                        <FinInstnId>
+                            <BICFI>NDEAFIHHXXX</BICFI>
+                        </FinInstnId>
+                    </FIId>
+                </To>
+                <BizMsgIdr>pacs9bizmsgidr01</BizMsgIdr>
+                <MsgDefIdr>pacs.009.001.08</MsgDefIdr>
+                <BizSvc>swift.cbprplus.02</BizSvc>
+                <CreDt>2020-08-03T10:13:41.960+00:00</CreDt>
+            </Rltd>
+        </AppHdr>
+        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:pacs.004.001.13">
+            <PmtRtr>
+                <GrpHdr>
+                    <MsgId>pacs4bizmsgidr02</MsgId>
+                    <CreDtTm>2020-08-03T12:13:41.960+00:00</CreDtTm>
+                    <NbOfTxs>1</NbOfTxs>
+                    <SttlmInf>
+                        <SttlmMtd>INGA</SttlmMtd>
+                    </SttlmInf>
+                </GrpHdr>
+                <TxInf>
+                    <OrgnlGrpInf>
+                        <OrgnlMsgId>pacs9bizmsgidr01</OrgnlMsgId>
+                        <OrgnlMsgNmId>pacs.009.001.08</OrgnlMsgNmId>
+                    </OrgnlGrpInf>
+                    <OrgnlInstrId>pacs9bizmsgidr01</OrgnlInstrId>
+                    <OrgnlEndToEndId>pacs009EndToEndId-001</OrgnlEndToEndId>
+                    <OrgnlUETR>dab3b64f-092b-4839-b7e9-8f438af50961</OrgnlUETR>
+                    <OrgnlIntrBkSttlmAmt Ccy="EUR">654489.98</OrgnlIntrBkSttlmAmt>
+                    <OrgnlIntrBkSttlmDt>2020-08-03</OrgnlIntrBkSttlmDt>
+                    <RtrdIntrBkSttlmAmt Ccy="EUR">654489.98</RtrdIntrBkSttlmAmt>
+                    <IntrBkSttlmDt>2020-08-03</IntrBkSttlmDt>
+                    <ChrgBr>SHAR</ChrgBr>
+                    <InstgAgt>
+                        <FinInstnId>
+                            <BICFI>NDEAFIHHXXX</BICFI>
+                        </FinInstnId>
+                    </InstgAgt>
+                    <InstdAgt>
+                        <FinInstnId>
+                            <BICFI>ABNANL2AXXX</BICFI>
+                        </FinInstnId>
+                    </InstdAgt>
+                    <RtrChain>
+                        <Dbtr>
+                            <Agt>
+                                <FinInstnId>
+                                    <BICFI>NDEAFIHHXXX</BICFI>
+                                </FinInstnId>
+                            </Agt>
+                        </Dbtr>
+                        <CdtrAgt>
+                            <FinInstnId>
+                                <BICFI>ABNANL2AXXX</BICFI>
+                            </FinInstnId>
+                        </CdtrAgt>
+                        <Cdtr>
+                            <Agt>
+                                <FinInstnId>
+                                    <BICFI>RBOSGB2LXXX</BICFI>
+                                </FinInstnId>
+                            </Agt>
+                        </Cdtr>
+                    </RtrChain>
+                    <RtrRsnInf>
+                        <Rsn>
+                            <Cd>AC04</Cd>
+                        </Rsn>
+                    </RtrRsnInf>
+                </TxInf>
+            </PmtRtr>
+        </Document>
+    </Envelope>`;
+    io:println(iso20022:fromIso20022(newXml, isorecord:Pacs004Envelope));
+}
 ```
-
-## Report issues
-
-To report bugs, request new features, start new discussions, view project boards, etc., go to
-the [Ballerina library parent repository](https://github.com/ballerina-platform/ballerina-library).
-
-## Useful Links
-
-- Chat live with us via our [Discord server](https://discord.gg/ballerinalang).
-- Post all technical questions on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag.

--- a/iso20022/Package.md
+++ b/iso20022/Package.md
@@ -44,36 +44,157 @@ The ISO 20022 library provides a comprehensive collection of ISO 20022 records, 
 
 ## Usage
 
-### Step 1: Import the library
-
-Import the `ballerinax/financial.iso20022.payment_initiation` library.
+### Create new ISO 20022 documents and Convert to XML
 
 ```ballerina
-import ballerinax/financial.iso20022.payment_initiation as isorecord;
+import ballerinax/financial.iso20022.payments_clearing_and_settlement as isorecord;
+import ballerinax/financial.iso20022 as iso20022;
+import ballerina/io;
+
+public function main() returns error? {
+    isorecord:Pacs004Envelope envelope = {
+        // AppHdr is optional so documents can be created with or without AppHdr.
+        AppHdr:{
+            Fr:{FIId:{FinInstnId:{BICFI:"NDEAFIHHXXX"}}},
+            To:{FIId:{FinInstnId:{"BICFI":"ABNANL2AXXX"}}},
+            BizMsgIdr:"pacs4bizmsgidr02",
+            MsgDefIdr:"pacs.004.001.09",
+            BizSvc:"swift.cbprplus.02",
+            CreDt:"2020-08-03T12:13:41.960+00:00",
+            Rltd:[
+                {Fr:{FIId:{FinInstnId:{BICFI:"ABNANL2AXXX"}}},
+                To:{FIId:{FinInstnId:{BICFI:"NDEAFIHHXXX"}}},
+                BizMsgIdr:"pacs9bizmsgidr01",
+                MsgDefIdr:"pacs.009.001.08",
+                BizSvc:"swift.cbprplus.02",
+                CreDt:"2020-08-03T10:13:41.960+00:00"}]},
+        Document:{
+            PmtRtr:{
+                GrpHdr:{
+                    MsgId:"pacs4bizmsgidr02",
+                    CreDtTm:"2020-08-03T12:13:41.960+00:00",
+                    NbOfTxs:"1",
+                    SttlmInf:{SttlmMtd:"INGA"}},
+                    TxInf:[
+                        {OrgnlGrpInf:{OrgnlMsgId:"pacs9bizmsgidr01",OrgnlMsgNmId:"pacs.009.001.08"},
+                        OrgnlInstrId:"pacs9bizmsgidr01",OrgnlEndToEndId:"pacs009EndToEndId-001",OrgnlUETR:"dab3b64f-092b-4839-b7e9-8f438af50961",OrgnlIntrBkSttlmAmt:{content:654489.98,Ccy:"EUR"},OrgnlIntrBkSttlmDt:"2020-08-03",RtrdIntrBkSttlmAmt:{content:654489.98,Ccy:"EUR"},IntrBkSttlmDt:"2020-08-03",ChrgBr:"SHAR",InstgAgt:{FinInstnId:{BICFI:"NDEAFIHHXXX"}},InstdAgt:{FinInstnId:{BICFI:"ABNANL2AXXX"}},RtrChain:{Dbtr:{Agt:{FinInstnId:{BICFI:"NDEAFIHHXXX"}}},CdtrAgt:{FinInstnId:{BICFI:"ABNANL2AXXX"}},Cdtr:{Agt:{FinInstnId:{BICFI:"RBOSGB2LXXX"}}}},RtrRsnInf:[{Rsn:{Cd:"AC04"}}]}]}}
+    };
+    io:println(iso20022:toIso20022Xml(envelope));
+}
 ```
 
-### Step 2: Create new ISO 20022 documents based on requirement
+### Parse ISO 20022 XML to Corresponding ISO 20022 Record Type
 
 ```ballerina
-isorecord:Pain001Document document = {
-    CstmrCdtTrfInitn: {
-        GrpHdr: {
-            CreDtTm: time:utcToString(time:utcNow()), 
-            InitgPty: {}, 
-            NbOfTxs: "1", 
-            MsgId: uuid:createType4AsString().substring(0, 11)
-        }, 
-        PmtInf: []
-    }
-};
+import ballerinax/financial.iso20022.payments_clearing_and_settlement as isorecord;
+import ballerinax/financial.iso20022 as iso20022;
+import ballerina/io;
+
+public function main() returns error? {
+    xml newXml = xml `<Envelope xmlns="urn:swift:xsd:envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:swift:xsd:envelope \\be-file02\Group\Standards\Messaging\CBPR+Schemas\Feb24Schemas_Core\Translator_envelope_core.xsd">
+        <AppHdr xmlns="urn:iso:std:iso:20022:tech:xsd:head.001.001.04">
+            <Fr>
+                <FIId>
+                    <FinInstnId>
+                        <BICFI>NDEAFIHHXXX</BICFI>
+                    </FinInstnId>
+                </FIId>
+            </Fr>
+            <To>
+                <FIId>
+                    <FinInstnId>
+                        <BICFI>ABNANL2AXXX</BICFI>
+                    </FinInstnId>
+                </FIId>
+            </To>
+            <BizMsgIdr>pacs4bizmsgidr02</BizMsgIdr>
+            <MsgDefIdr>pacs.004.001.09</MsgDefIdr>
+            <BizSvc>swift.cbprplus.02</BizSvc>
+            <CreDt>2020-08-03T12:13:41.960+00:00</CreDt>
+            <Rltd>
+                <Fr>
+                    <FIId>
+                        <FinInstnId>
+                            <BICFI>ABNANL2AXXX</BICFI>
+                        </FinInstnId>
+                    </FIId>
+                </Fr>
+                <To>
+                    <FIId>
+                        <FinInstnId>
+                            <BICFI>NDEAFIHHXXX</BICFI>
+                        </FinInstnId>
+                    </FIId>
+                </To>
+                <BizMsgIdr>pacs9bizmsgidr01</BizMsgIdr>
+                <MsgDefIdr>pacs.009.001.08</MsgDefIdr>
+                <BizSvc>swift.cbprplus.02</BizSvc>
+                <CreDt>2020-08-03T10:13:41.960+00:00</CreDt>
+            </Rltd>
+        </AppHdr>
+        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:pacs.004.001.13">
+            <PmtRtr>
+                <GrpHdr>
+                    <MsgId>pacs4bizmsgidr02</MsgId>
+                    <CreDtTm>2020-08-03T12:13:41.960+00:00</CreDtTm>
+                    <NbOfTxs>1</NbOfTxs>
+                    <SttlmInf>
+                        <SttlmMtd>INGA</SttlmMtd>
+                    </SttlmInf>
+                </GrpHdr>
+                <TxInf>
+                    <OrgnlGrpInf>
+                        <OrgnlMsgId>pacs9bizmsgidr01</OrgnlMsgId>
+                        <OrgnlMsgNmId>pacs.009.001.08</OrgnlMsgNmId>
+                    </OrgnlGrpInf>
+                    <OrgnlInstrId>pacs9bizmsgidr01</OrgnlInstrId>
+                    <OrgnlEndToEndId>pacs009EndToEndId-001</OrgnlEndToEndId>
+                    <OrgnlUETR>dab3b64f-092b-4839-b7e9-8f438af50961</OrgnlUETR>
+                    <OrgnlIntrBkSttlmAmt Ccy="EUR">654489.98</OrgnlIntrBkSttlmAmt>
+                    <OrgnlIntrBkSttlmDt>2020-08-03</OrgnlIntrBkSttlmDt>
+                    <RtrdIntrBkSttlmAmt Ccy="EUR">654489.98</RtrdIntrBkSttlmAmt>
+                    <IntrBkSttlmDt>2020-08-03</IntrBkSttlmDt>
+                    <ChrgBr>SHAR</ChrgBr>
+                    <InstgAgt>
+                        <FinInstnId>
+                            <BICFI>NDEAFIHHXXX</BICFI>
+                        </FinInstnId>
+                    </InstgAgt>
+                    <InstdAgt>
+                        <FinInstnId>
+                            <BICFI>ABNANL2AXXX</BICFI>
+                        </FinInstnId>
+                    </InstdAgt>
+                    <RtrChain>
+                        <Dbtr>
+                            <Agt>
+                                <FinInstnId>
+                                    <BICFI>NDEAFIHHXXX</BICFI>
+                                </FinInstnId>
+                            </Agt>
+                        </Dbtr>
+                        <CdtrAgt>
+                            <FinInstnId>
+                                <BICFI>ABNANL2AXXX</BICFI>
+                            </FinInstnId>
+                        </CdtrAgt>
+                        <Cdtr>
+                            <Agt>
+                                <FinInstnId>
+                                    <BICFI>RBOSGB2LXXX</BICFI>
+                                </FinInstnId>
+                            </Agt>
+                        </Cdtr>
+                    </RtrChain>
+                    <RtrRsnInf>
+                        <Rsn>
+                            <Cd>AC04</Cd>
+                        </Rsn>
+                    </RtrRsnInf>
+                </TxInf>
+            </PmtRtr>
+        </Document>
+    </Envelope>`;
+    io:println(iso20022:fromIso20022(newXml, isorecord:Pacs004Envelope));
+}
 ```
-
-## Report issues
-
-To report bugs, request new features, start new discussions, view project boards, etc., go to
-the [Ballerina library parent repository](https://github.com/ballerina-platform/ballerina-library).
-
-## Useful Links
-
-- Chat live with us via our [Discord server](https://discord.gg/ballerinalang).
-- Post all technical questions on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag.

--- a/iso20022/modules/cash_management/camt.026.001.10.bal
+++ b/iso20022/modules/cash_management/camt.026.001.10.bal
@@ -34,9 +34,6 @@ public type AMLIndicator boolean;
 # Defines the Camt026Document structure.
 #
 # + UblToApply - The unable to apply information
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.026.001.10"
-}
 public type Camt026Document record {|
     UnableToApplyV10 UblToApply;
 |};

--- a/iso20022/modules/cash_management/camt.027.001.10.bal
+++ b/iso20022/modules/cash_management/camt.027.001.10.bal
@@ -48,9 +48,6 @@ public type ClaimNonReceiptV10 record {|
 # Defines the Camt027Document structure.
 #
 # + ClmNonRct - Claim non-receipt details
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.027.001.10"
-}
 public type Camt027Document record {|
     ClaimNonReceiptV10 ClmNonRct;
 |};

--- a/iso20022/modules/cash_management/camt.028.001.12.bal
+++ b/iso20022/modules/cash_management/camt.028.001.12.bal
@@ -46,9 +46,6 @@ public type AdditionalPaymentInformationV12 record {|
 # Defines the Camt028Document structure.
 #
 # + AddtlPmtInf - Additional payment information details
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.028.001.12"
-}
 public type Camt028Document record {|
     AdditionalPaymentInformationV12 AddtlPmtInf;
 |};

--- a/iso20022/modules/cash_management/camt.029.001.13.bal
+++ b/iso20022/modules/cash_management/camt.029.001.13.bal
@@ -181,9 +181,6 @@ public type CorrectiveTransaction5Choice record {|
 # Defines the Camt029Document structure.
 #
 # + RsltnOfInvstgtn - The resolution of the investigation details
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.029.001.13"
-}
 public type Camt029Document record {|
     ResolutionOfInvestigationV13 RsltnOfInvstgtn;
 |};

--- a/iso20022/modules/cash_management/camt.031.001.07.bal
+++ b/iso20022/modules/cash_management/camt.031.001.07.bal
@@ -31,9 +31,6 @@ public type Camt031Envelope record {|
 # Defines the structure for Camt031Document, a record that holds the rejection investigation details.
 #
 # + RjctInvstgtn - The rejection investigation details
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.031.001.07"
-}
 public type Camt031Document record {|
     RejectInvestigationV07 RjctInvstgtn;
 |};

--- a/iso20022/modules/cash_management/camt.033.001.07.bal
+++ b/iso20022/modules/cash_management/camt.033.001.07.bal
@@ -31,9 +31,6 @@ public type Camt033Envelope record {|
 # Defines the structure for Camt033Document, a record that holds the request for duplicate message details.
 #
 # + ReqForDplct - The request for a duplicate of the previously sent message
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.033.001.07"
-}
 public type Camt033Document record {|
     RequestForDuplicateV07 ReqForDplct;
 |};

--- a/iso20022/modules/cash_management/camt.034.001.07.bal
+++ b/iso20022/modules/cash_management/camt.034.001.07.bal
@@ -31,9 +31,6 @@ public type Camt034Envelope record {|
 # Defines the structure for Camt034Document, a record that holds the duplicate message details.
 #
 # + Dplct - The duplicate message content with its case and proprietary data
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.034.001.07"
-}
 public type Camt034Document record {|
     DuplicateV07 Dplct;
 |};

--- a/iso20022/modules/cash_management/camt.050.001.07.bal
+++ b/iso20022/modules/cash_management/camt.050.001.07.bal
@@ -40,9 +40,6 @@ public type Amount2Choice record {|
 # Defines the structure for the Camt050Document, which contains liquidity credit transfer details.
 #
 # + LqdtyCdtTrf - The liquidity credit transfer message details
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.050.001.07"
-}
 public type Camt050Document record {|
     LiquidityCreditTransferV07 LqdtyCdtTrf;
 |};

--- a/iso20022/modules/cash_management/camt.052.001.12.bal
+++ b/iso20022/modules/cash_management/camt.052.001.12.bal
@@ -79,9 +79,6 @@ public type BankToCustomerAccountReportV12 record {|
 # Defines the structure for the Camt052Document, which contains the bank-to-customer account report details.
 #
 # + BkToCstmrAcctRpt - The bank-to-customer account report
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.052.001.12"
-}
 public type Camt052Document record {|
     BankToCustomerAccountReportV12 BkToCstmrAcctRpt;
 |};

--- a/iso20022/modules/cash_management/camt.053.001.12.bal
+++ b/iso20022/modules/cash_management/camt.053.001.12.bal
@@ -79,9 +79,6 @@ public type BankToCustomerStatementV12 record {|
 # Defines the structure for the Camt053Document, which contains the bank-to-customer statement details.
 #
 # + BkToCstmrStmt - The bank-to-customer statement
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.053.001.12"
-}
 public type Camt053Document record {|
     BankToCustomerStatementV12 BkToCstmrStmt;
 |};

--- a/iso20022/modules/cash_management/camt.054.001.12.bal
+++ b/iso20022/modules/cash_management/camt.054.001.12.bal
@@ -77,9 +77,6 @@ public type BankToCustomerDebitCreditNotificationV12 record {|
 # Defines the structure for the Camt054Document, which contains the bank-to-customer debit/credit notification details.
 #
 # + BkToCstmrDbtCdtNtfctn - The bank-to-customer debit/credit notification
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.054.001.12"
-}
 public type Camt054Document record {|
     BankToCustomerDebitCreditNotificationV12 BkToCstmrDbtCdtNtfctn;
 |};

--- a/iso20022/modules/cash_management/camt.055.001.12.bal
+++ b/iso20022/modules/cash_management/camt.055.001.12.bal
@@ -46,9 +46,6 @@ public type CustomerPaymentCancellationRequestV12 record {|
 # Defines the structure for Camt055Document, which contains the customer payment cancellation request details.
 #
 # + CstmrPmtCxlReq - The customer payment cancellation request
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.055.001.12"
-}
 public type Camt055Document record {|
     CustomerPaymentCancellationRequestV12 CstmrPmtCxlReq;
 |};

--- a/iso20022/modules/cash_management/camt.056.001.11.bal
+++ b/iso20022/modules/cash_management/camt.056.001.11.bal
@@ -31,9 +31,6 @@ public type Camt056Envelope record {|
 # Defines the structure for Camt056Document, which contains the FI to FI payment cancellation request details.
 #
 # + FIToFIPmtCxlReq - The FI to FI payment cancellation request
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.056.001.11"
-}
 public type Camt056Document record {|
     FIToFIPaymentCancellationRequestV11 FIToFIPmtCxlReq;
 |};

--- a/iso20022/modules/cash_management/camt.057.001.08.bal
+++ b/iso20022/modules/cash_management/camt.057.001.08.bal
@@ -58,9 +58,6 @@ public type AccountNotification23 record {|
 # Defines the structure for Camt057Document, which contains the notification to receive details.
 #
 # + NtfctnToRcv - The notification to receive
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.057.001.08"
-}
 public type Camt057Document record {|
     NotificationToReceiveV08 NtfctnToRcv;
 |};

--- a/iso20022/modules/cash_management/camt.058.001.09.bal
+++ b/iso20022/modules/cash_management/camt.058.001.09.bal
@@ -31,9 +31,6 @@ public type Camt058Envelope record {|
 # Represents the root element for the Notification to Receive Cancellation Advice (camt.058) message.
 #
 # + NtfctnToRcvCxlAdvc - Details of the notification to receive cancellation advice
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.058.001.09"
-}
 public type Camt058Document record {|
     NotificationToReceiveCancellationAdviceV09 NtfctnToRcvCxlAdvc;
 |};

--- a/iso20022/modules/cash_management/camt.060.001.07.bal
+++ b/iso20022/modules/cash_management/camt.060.001.07.bal
@@ -51,9 +51,6 @@ public type DatePeriod3 record {|
 # Defines the structure for Camt060Document, which encapsulates the account reporting request details.
 #
 # + AcctRptgReq - Account reporting request information
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.060.001.07"
-}
 public type Camt060Document record {|
     AccountReportingRequestV07 AcctRptgReq;
 |};

--- a/iso20022/modules/cash_management/camt.105.001.02.bal
+++ b/iso20022/modules/cash_management/camt.105.001.02.bal
@@ -1,0 +1,202 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/data.xmldata;
+
+# Defines the Camt105Envelope structure containing the Business Application Header
+# and the Document body.
+#
+# + AppHdr - Business Application Header  
+# + Document - Camt105Document
+@xmldata:Name {
+    value: "Envelope"
+}
+public type Camt105Envelope record {|
+    BusinessApplicationHeaderV04 AppHdr?;
+    Camt105Document Document;
+|};
+
+# Defines the Charges4Choice structure to represent charge options.
+#
+# + Sngl - Single set of charges.
+# + PerTx - Charges per transaction.
+# + PerTp - Charges per type.
+public type Charges4Choice record {|
+    ChargesRecord10 Sngl?;
+    ChargesPerTransaction4 PerTx?;
+    ChargesPerType4 PerTp?;
+|};
+
+# Defines the ChargesPaymentNotificationV02 structure representing the notification of charges payment.
+#
+# + GrpHdr - Group header information.
+# + Chrgs - Charges information.
+# + SplmtryData - Supplementary data.
+public type ChargesPaymentNotificationV02 record {|
+    GroupHeader126 GrpHdr;
+    Charges4Choice Chrgs;
+    SupplementaryData1[] SplmtryData?;
+|};
+
+# Defines the ChargesPerTransaction4 structure representing charges per transaction.
+#
+# + ChrgsId - Unique identifier for charges.
+# + TtlChrgsPerTx - Total charges for the transaction.
+# + ChrgsAcct - Charges account details.
+# + ChrgsAcctOwnr - Owner of the charges account.
+# + Rcrd - Records of charges per transaction.
+# + AddtlInf - Additional information.
+public type ChargesPerTransaction4 record {|
+    Max35Text ChrgsId?;
+    TotalCharges7 TtlChrgsPerTx?;
+    CashAccount40 ChrgsAcct?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctOwnr?;
+    ChargesPerTransactionRecord4[] Rcrd;
+    Max140Text AddtlInf?;
+|};
+
+# Defines the ChargesPerTransactionRecord4 structure representing records of charges per transaction.
+#
+# + RcrdId - Record identifier.
+# + ChrgsRqstr - Charges requester information.
+# + UndrlygTx - Underlying transaction references.
+# + TtlChrgsPerRcrd - Total charges for the record.
+# + ChrgsBrkdwn - Breakdown of charges.
+# + ValDt - Value date.
+# + DbtrAgt - Debtor agent details.
+# + DbtrAgtAcct - Debtor agent account details.
+# + ChrgsAcct - Charges account details.
+# + ChrgsAcctOwnr - Owner of the charges account.
+# + InstrForInstdAgt - Instructions for the instructed agent.
+# + AddtlInf - Additional information.
+public type ChargesPerTransactionRecord4 record {|
+    Max35Text RcrdId?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsRqstr?;
+    TransactionReferences7 UndrlygTx;
+    TotalCharges8 TtlChrgsPerRcrd?;
+    ChargesBreakdown1[] ChrgsBrkdwn;
+    DateAndDateTime2Choice ValDt?;
+    BranchAndFinancialInstitutionIdentification8 DbtrAgt?;
+    CashAccount40 DbtrAgtAcct?;
+    CashAccount40 ChrgsAcct?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctOwnr?;
+    InstructionForInstructedAgent1 InstrForInstdAgt?;
+    Max140Text AddtlInf?;
+|};
+
+# Defines the ChargesPerType4 structure representing charges per type.
+#
+# + ChrgsId - Unique identifier for charges.
+# + TtlChrgsPerChrgTp - Total charges for the charge type.
+# + ChrgsAcct - Charges account details.
+# + ChrgsAcctOwnr - Owner of the charges account.
+# + Tp - Charge type.
+# + Rcrd - Records of charges per type.
+# + AddtlInf - Additional information.
+public type ChargesPerType4 record {|
+    Max35Text ChrgsId?;
+    TotalCharges7 TtlChrgsPerChrgTp?;
+    CashAccount40 ChrgsAcct?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctOwnr?;
+    ChargeType3Choice Tp;
+    ChargesPerTypeRecord4[] Rcrd;
+    Max140Text AddtlInf?;
+|};
+
+# Defines the ChargesPerTypeRecord4 structure representing records of charges per type.
+#
+# + RcrdId - Record identifier.
+# + ChrgsRqstr - Charges requester information.
+# + UndrlygTx - Underlying transaction references.
+# + Amt - Amount of charges.
+# + CdtDbtInd - Credit or debit indicator.
+# + ValDt - Value date.
+# + DbtrAgt - Debtor agent details.
+# + DbtrAgtAcct - Debtor agent account details.
+# + ChrgsAcct - Charges account details.
+# + ChrgsAcctOwnr - Owner of the charges account.
+# + InstrForInstdAgt - Instructions for the instructed agent.
+# + AddtlInf - Additional information.
+public type ChargesPerTypeRecord4 record {|
+    Max35Text RcrdId?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsRqstr?;
+    TransactionReferences7 UndrlygTx;
+    ActiveCurrencyAndAmount Amt;
+    CreditDebitCode CdtDbtInd?;
+    DateAndDateTime2Choice ValDt?;
+    BranchAndFinancialInstitutionIdentification8 DbtrAgt?;
+    CashAccount40 DbtrAgtAcct?;
+    CashAccount40 ChrgsAcct?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctOwnr?;
+    InstructionForInstructedAgent1 InstrForInstdAgt?;
+    Max140Text AddtlInf?;
+|};
+
+# Defines the ChargesRecord10 structure representing individual charge records.
+#
+# + ChrgsId - Unique identifier for charges.
+# + RcrdId - Record identifier.
+# + ChrgsRqstr - Charges requester information.
+# + UndrlygTx - Underlying transaction references.
+# + Amt - Amount of charges.
+# + CdtDbtInd - Credit or debit indicator.
+# + ValDt - Value date.
+# + DbtrAgt - Debtor agent details.
+# + DbtrAgtAcct - Debtor agent account details.
+# + ChrgsAcct - Charges account details.
+# + ChrgsAcctOwnr - Owner of the charges account.
+# + Tp - Type of charges.
+# + InstrForInstdAgt - Instructions for the instructed agent.
+# + AddtlInf - Additional information.
+public type ChargesRecord10 record {|
+    Max35Text ChrgsId?;
+    Max35Text RcrdId?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsRqstr?;
+    TransactionReferences7 UndrlygTx;
+    ActiveCurrencyAndAmount Amt;
+    CreditDebitCode CdtDbtInd?;
+    DateAndDateTime2Choice ValDt?;
+    BranchAndFinancialInstitutionIdentification8 DbtrAgt?;
+    CashAccount40 DbtrAgtAcct?;
+    CashAccount40 ChrgsAcct?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctOwnr?;
+    ChargeType3Choice Tp?;
+    InstructionForInstructedAgent1 InstrForInstdAgt?;
+    Max140Text AddtlInf?;
+|};
+
+# Defines the Camt105Document structure representing the Charges Payment Notification.
+#
+# + ChrgsPmtNtfctn - Charges payment notification details.
+public type Camt105Document record {|
+    ChargesPaymentNotificationV02 ChrgsPmtNtfctn;
+|};
+
+# Defines the GroupHeader126 structure representing group-level header details.
+#
+# + MsgId - Unique identifier for the message.
+# + CreDtTm - Creation date and time.
+# + ChrgsRqstr - Charges requester information.
+# + TtlChrgs - Total charges information.
+# + ChrgsAcct - Charges account details.
+# + ChrgsAcctOwnr - Owner of the charges account.
+public type GroupHeader126 record {|
+    Max35Text MsgId;
+    ISODateTime CreDtTm;
+    BranchAndFinancialInstitutionIdentification8 ChrgsRqstr?;
+    TotalCharges7 TtlChrgs?;
+    CashAccount40 ChrgsAcct?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctOwnr?;
+|};

--- a/iso20022/modules/cash_management/camt.106.001.02.bal
+++ b/iso20022/modules/cash_management/camt.106.001.02.bal
@@ -1,0 +1,202 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/data.xmldata;
+
+# Defines the Camt106Envelope structure containing the Business Application Header
+# and the Document body.
+#
+# + AppHdr - Business Application Header  
+# + Document - Camt106Document
+@xmldata:Name {
+    value: "Envelope"
+}
+public type Camt106Envelope record {|
+    BusinessApplicationHeaderV04 AppHdr?;
+    Camt106Document Document;
+|};
+
+# Defines the Charges3Choice structure, which allows for different choices of charge records.
+#
+# + Sngl - Single charge record.
+# + PerTx - Charges per transaction.
+# + PerTp - Charges per type.
+public type Charges3Choice record {|
+    ChargesRecord9 Sngl?;
+    ChargesPerTransaction3 PerTx?;
+    ChargesPerType3 PerTp?;
+|};
+
+# Defines the ChargesPaymentRequestV02 structure, representing a charges payment request.
+#
+# + GrpHdr - Group header information.
+# + Chrgs - Charges details with different choices.
+# + SplmtryData - Supplementary data, if any.
+public type ChargesPaymentRequestV02 record {|
+    GroupHeader115 GrpHdr;
+    Charges3Choice Chrgs;
+    SupplementaryData1[] SplmtryData?;
+|};
+
+# Defines the ChargesPerTransaction3 structure, representing charges per transaction details.
+#
+# + ChrgsId - Identifier for the charges.
+# + TtlChrgsPerTx - Total charges for the transaction.
+# + ChrgsAcctAgt - Charges account agent details.
+# + ChrgsAcctAgtAcct - Charges account agent account details.
+# + Rcrd - List of charge records per transaction.
+# + AddtlInf - Additional information.
+public type ChargesPerTransaction3 record {|
+    Max35Text ChrgsId?;
+    TotalCharges7 TtlChrgsPerTx?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctAgt?;
+    CashAccount40 ChrgsAcctAgtAcct?;
+    ChargesPerTransactionRecord3[] Rcrd;
+    Max140Text AddtlInf?;
+|};
+
+# Defines the ChargesPerTransactionRecord3 structure, representing detailed charges per transaction record.
+#
+# + RcrdId - Record identifier.
+# + ChrgsRqstr - Charges requester details.
+# + UndrlygTx - Underlying transaction references.
+# + TtlChrgsPerRcrd - Total charges for the record.
+# + ChrgsBrkdwn - Breakdown of charges.
+# + ValDt - Value date.
+# + DbtrAgt - Debtor agent details.
+# + DbtrAgtAcct - Debtor agent account details.
+# + ChrgsAcctAgt - Charges account agent details.
+# + ChrgsAcctAgtAcct - Charges account agent account details.
+# + InstrForInstdAgt - Instructions for the instructed agent.
+# + AddtlInf - Additional information.
+public type ChargesPerTransactionRecord3 record {|
+    Max35Text RcrdId?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsRqstr?;
+    TransactionReferences7 UndrlygTx;
+    TotalCharges8 TtlChrgsPerRcrd?;
+    ChargesBreakdown1[] ChrgsBrkdwn;
+    DateAndDateTime2Choice ValDt?;
+    BranchAndFinancialInstitutionIdentification8 DbtrAgt?;
+    CashAccount40 DbtrAgtAcct?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctAgt?;
+    CashAccount40 ChrgsAcctAgtAcct?;
+    InstructionForInstructedAgent1 InstrForInstdAgt?;
+    Max140Text AddtlInf?;
+|};
+
+# Defines the ChargesPerType3 structure, representing charges grouped by type.
+#
+# + ChrgsId - Identifier for the charges.
+# + TtlChrgsPerChrgTp - Total charges for the charge type.
+# + ChrgsAcctAgt - Charges account agent details.
+# + ChrgsAcctAgtAcct - Charges account agent account details.
+# + Tp - Type of charges.
+# + Rcrd - List of charge records per type.
+# + AddtlInf - Additional information.
+public type ChargesPerType3 record {|
+    Max35Text ChrgsId?;
+    TotalCharges7 TtlChrgsPerChrgTp?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctAgt?;
+    CashAccount40 ChrgsAcctAgtAcct?;
+    ChargeType3Choice Tp;
+    ChargesPerTypeRecord3[] Rcrd;
+    Max140Text AddtlInf?;
+|};
+
+# Defines the ChargesPerTypeRecord3 structure, representing detailed charges per type record.
+#
+# + RcrdId - Record identifier.
+# + ChrgsRqstr - Charges requester details.
+# + UndrlygTx - Underlying transaction references.
+# + Amt - Amount of the charges.
+# + CdtDbtInd - Credit or debit indicator.
+# + ValDt - Value date.
+# + DbtrAgt - Debtor agent details.
+# + DbtrAgtAcct - Debtor agent account details.
+# + ChrgsAcctAgt - Charges account agent details.
+# + ChrgsAcctAgtAcct - Charges account agent account details.
+# + InstrForInstdAgt - Instructions for the instructed agent.
+# + AddtlInf - Additional information.
+public type ChargesPerTypeRecord3 record {|
+    Max35Text RcrdId?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsRqstr?;
+    TransactionReferences7 UndrlygTx;
+    ActiveCurrencyAndAmount Amt;
+    CreditDebitCode CdtDbtInd?;
+    DateAndDateTime2Choice ValDt?;
+    BranchAndFinancialInstitutionIdentification8 DbtrAgt?;
+    CashAccount40 DbtrAgtAcct?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctAgt?;
+    CashAccount40 ChrgsAcctAgtAcct?;
+    InstructionForInstructedAgent1 InstrForInstdAgt?;
+    Max140Text AddtlInf?;
+|};
+
+# Defines the ChargesRecord9 structure, representing an individual charge record.
+#
+# + ChrgsId - Identifier for the charges.
+# + RcrdId - Record identifier.
+# + ChrgsRqstr - Charges requester details.
+# + UndrlygTx - Underlying transaction references.
+# + Amt - Amount of the charges.
+# + CdtDbtInd - Credit or debit indicator.
+# + ValDt - Value date.
+# + DbtrAgt - Debtor agent details.
+# + DbtrAgtAcct - Debtor agent account details.
+# + ChrgsAcctAgt - Charges account agent details.
+# + ChrgsAcctAgtAcct - Charges account agent account details.
+# + Tp - Type of charges.
+# + InstrForInstdAgt - Instructions for the instructed agent.
+# + AddtlInf - Additional information.
+public type ChargesRecord9 record {|
+    Max35Text ChrgsId?;
+    Max35Text RcrdId?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsRqstr?;
+    TransactionReferences7 UndrlygTx;
+    ActiveCurrencyAndAmount Amt;
+    CreditDebitCode CdtDbtInd?;
+    DateAndDateTime2Choice ValDt?;
+    BranchAndFinancialInstitutionIdentification8 DbtrAgt?;
+    CashAccount40 DbtrAgtAcct?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctAgt?;
+    CashAccount40 ChrgsAcctAgtAcct?;
+    ChargeType3Choice Tp?;
+    InstructionForInstructedAgent1 InstrForInstdAgt?;
+    Max140Text AddtlInf?;
+|};
+
+# Defines the Document structure, representing a document containing a charges payment request.
+#
+# + ChrgsPmtReq - Charges payment request details.
+public type Camt106Document record {|
+    ChargesPaymentRequestV02 ChrgsPmtReq;
+|};
+
+# Defines the GroupHeader115 structure, representing group-level header information.
+#
+# + MsgId - Message identifier.
+# + CreDtTm - Creation date and time.
+# + ChrgsRqstr - Charges requester details.
+# + TtlChrgs - Total charges information.
+# + ChrgsAcctAgt - Charges account agent details.
+# + ChrgsAcctAgtAcct - Charges account agent account details.
+public type GroupHeader115 record {|
+    Max35Text MsgId;
+    ISODateTime CreDtTm;
+    BranchAndFinancialInstitutionIdentification8 ChrgsRqstr?;
+    TotalCharges7 TtlChrgs?;
+    BranchAndFinancialInstitutionIdentification8 ChrgsAcctAgt?;
+    CashAccount40 ChrgsAcctAgtAcct?;
+|};

--- a/iso20022/modules/cash_management/camt.107.001.02.bal
+++ b/iso20022/modules/cash_management/camt.107.001.02.bal
@@ -73,9 +73,6 @@ public type ChequePresentmentNotificationV02 record {|
 # Represents the root element for the Cheque Presentment Notification (camt.107) message.
 #
 # + ChqPresntmntNtfctn - Details of the cheque presentment notification
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.107.001.02"
-}
 public type Camt107Document record {|
     ChequePresentmentNotificationV02 ChqPresntmntNtfctn;
 |};

--- a/iso20022/modules/cash_management/camt.108.001.02.bal
+++ b/iso20022/modules/cash_management/camt.108.001.02.bal
@@ -91,9 +91,6 @@ public type ChequeCancellationReason1Choice record {|
 # Represents the root element for the Cheque Cancellation or Stop Request (camt.108) message.
 #
 # + ChqCxlOrStopReq - Details of the cheque cancellation or stop request
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.108.001.02"
-}
 public type Camt108Document record {|
     ChequeCancellationOrStopRequestV02 ChqCxlOrStopReq;
 |};

--- a/iso20022/modules/cash_management/camt.109.001.02.bal
+++ b/iso20022/modules/cash_management/camt.109.001.02.bal
@@ -91,9 +91,6 @@ public type ChequeCancellationStatus1Choice record {|
 # Defines the structure for Camt109Document, which represents the root document for a cheque cancellation or stop report.
 #
 # + ChqCxlOrStopRpt - Report containing details of cheques and their cancellation or stop status.
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:camt.109.001.02"
-}
 public type Camt109Document record {|
     ChequeCancellationOrStopReportV02 ChqCxlOrStopRpt;
 |};

--- a/iso20022/modules/cash_management/common_records.bal
+++ b/iso20022/modules/cash_management/common_records.bal
@@ -3261,3 +3261,92 @@ public type GroupHeader103 record {|
 public enum ChequePartyRole1Code {
     DWEA, DWRA, PAYE, PAYR
 };
+
+# Defines the ActiveCurrencyAndAmount_SimpleType as a decimal value.
+public type ActiveCurrencyAndAmount_SimpleType decimal;
+
+# Defines the ChargesBreakdown1 structure to represent the breakdown of charges.
+#
+# + Amt - Amount of charges in active currency.
+# + CdtDbtInd - Credit or debit indicator.
+# + Tp - Type of charges.
+public type ChargesBreakdown1 record {|
+    ActiveCurrencyAndAmount Amt;
+    CreditDebitCode CdtDbtInd?;
+    ChargeType3Choice Tp?;
+|};
+
+# Defines the ExternalInstructedAgentInstruction1Code type as a string for instructed agent instructions.
+public type ExternalInstructedAgentInstruction1Code string;
+
+# Defines the InstructionForInstructedAgent1 structure representing instructions for the instructed agent.
+#
+# + Cd - Code representing the instruction.
+# + InstrInf - Instruction information in text.
+public type InstructionForInstructedAgent1 record {|
+    ExternalInstructedAgentInstruction1Code Cd?;
+    Max140Text InstrInf?;
+|};
+
+# Defines the TotalCharges7 structure representing total charges information.
+#
+# + NbOfChrgsRcrds - Number of charges records.
+# + CtrlSum - Control sum for total charges.
+# + TtlChrgsAmt - Total charges amount.
+# + CdtDbtInd - Credit or debit indicator.
+public type TotalCharges7 record {|
+    Max15NumericText NbOfChrgsRcrds;
+    DecimalNumber CtrlSum?;
+    ActiveCurrencyAndAmount TtlChrgsAmt?;
+    CreditDebitCode CdtDbtInd?;
+|};
+
+# Defines the TotalCharges8 structure representing detailed total charges information.
+#
+# + NbOfChrgsBrkdwnItms - Number of charges breakdown items.
+# + CtrlSum - Control sum for total charges.
+# + TtlChrgsAmt - Total charges amount.
+# + CdtDbtInd - Credit or debit indicator.
+public type TotalCharges8 record {|
+    Max15NumericText NbOfChrgsBrkdwnItms;
+    DecimalNumber CtrlSum?;
+    ActiveCurrencyAndAmount TtlChrgsAmt?;
+    CreditDebitCode CdtDbtInd?;
+|};
+
+# Defines the TransactionReferences7 structure representing references for transactions.
+#
+# + MsgId - Message identifier.
+# + MsgNmId - Message name identifier.
+# + AcctSvcrRef - Account servicing reference.
+# + PmtInfId - Payment information identifier.
+# + InstrId - Instruction identifier.
+# + EndToEndId - End-to-end identifier.
+# + UETR - Unique end-to-end transaction reference.
+# + TxId - Transaction identifier.
+# + MndtId - Mandate identifier.
+# + ChqNb - Cheque number.
+# + ClrSysRef - Clearing system reference.
+# + AcctOwnrTxId - Account owner transaction identifier.
+# + AcctSvcrTxId - Account servicing transaction identifier.
+# + MktInfrstrctrTxId - Market infrastructure transaction identifier.
+# + PrcgId - Processing identifier.
+# + Prtry - Proprietary references.
+public type TransactionReferences7 record {|
+    Max35Text MsgId?;
+    Max35Text MsgNmId?;
+    Max35Text AcctSvcrRef?;
+    Max35Text PmtInfId?;
+    Max35Text InstrId?;
+    Max35Text EndToEndId?;
+    UUIDv4Identifier UETR?;
+    Max35Text TxId?;
+    Max35Text MndtId?;
+    Max35Text ChqNb?;
+    Max35Text ClrSysRef?;
+    Max35Text AcctOwnrTxId?;
+    Max35Text AcctSvcrTxId?;
+    Max35Text MktInfrstrctrTxId?;
+    Max35Text PrcgId?;
+    ProprietaryReference1[] Prtry?;
+|};

--- a/iso20022/modules/cash_management/header.001.001.04.bal
+++ b/iso20022/modules/cash_management/header.001.001.04.bal
@@ -1,5 +1,3 @@
-import ballerina/data.xmldata;
-
 # Defines the AppHdr type as a reference to BusinessApplicationHeaderV04.
 public type AppHdr BusinessApplicationHeaderV04;
 
@@ -50,9 +48,6 @@ public type BusinessApplicationHeader8 record {|
 # + Prty - Business message priority
 # + Sgntr - Digital signature details
 # + Rltd - Related business application headers
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:head.001.001.04"
-}
 public type BusinessApplicationHeaderV04 record {|
     UnicodeChartsCode CharSet?;
     Party51Choice Fr;

--- a/iso20022/modules/payment_initiation/header.001.001.04.bal
+++ b/iso20022/modules/payment_initiation/header.001.001.04.bal
@@ -1,5 +1,3 @@
-import ballerina/data.xmldata;
-
 # Defines the AppHdr type as a reference to BusinessApplicationHeaderV04.
 public type AppHdr BusinessApplicationHeaderV04;
 
@@ -50,9 +48,6 @@ public type BusinessApplicationHeader8 record {|
 # + Prty - Business message priority
 # + Sgntr - Digital signature details
 # + Rltd - Related business application headers
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:head.001.001.04"
-}
 public type BusinessApplicationHeaderV04 record {|
     UnicodeChartsCode CharSet?;
     Party51Choice Fr;

--- a/iso20022/modules/payment_initiation/pain.001.001.12.bal
+++ b/iso20022/modules/payment_initiation/pain.001.001.12.bal
@@ -145,9 +145,6 @@ public type CustomerCreditTransferInitiationV12 record {|
 # Defines the structure for Pain001Document, which encapsulates the customer credit transfer initiation information.
 #
 # + CstmrCdtTrfInitn - Customer credit transfer initiation information
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:pain.001.001.12"
-}
 public type Pain001Document record {|
     CustomerCreditTransferInitiationV12 CstmrCdtTrfInitn;
 |};

--- a/iso20022/modules/payment_initiation/pain.002.001.14.bal
+++ b/iso20022/modules/payment_initiation/pain.002.001.14.bal
@@ -57,9 +57,6 @@ public type CustomerPaymentStatusReportV14 record {|
 # Represents the root element for a Payment Status Report in the pain.002 message.
 #
 # + CstmrPmtStsRpt - The payment status report details
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:pain.002.001.14"
-}
 public type Pain002Document record {|
     CustomerPaymentStatusReportV14 CstmrPmtStsRpt;
 |};

--- a/iso20022/modules/payment_initiation/pain.008.001.11.bal
+++ b/iso20022/modules/payment_initiation/pain.008.001.11.bal
@@ -83,9 +83,6 @@ public type DirectDebitTransactionInformation32 record {|
 # Defines the structure for Pain008Document, which encapsulates the customer direct debit initiation information.
 #
 # + CstmrDrctDbtInitn - Customer direct debit initiation information
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:pain.008.001.11"
-}
 public type Pain008Document record {|
     CustomerDirectDebitInitiationV11 CstmrDrctDbtInitn;
 |};

--- a/iso20022/modules/payments_clearing_and_settlement/header.001.001.04.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/header.001.001.04.bal
@@ -1,5 +1,3 @@
-import ballerina/data.xmldata;
-
 # Defines the AppHdr type as a reference to BusinessApplicationHeaderV04.
 public type AppHdr BusinessApplicationHeaderV04;
 
@@ -50,9 +48,6 @@ public type BusinessApplicationHeader8 record {|
 # + Prty - Business message priority
 # + Sgntr - Digital signature details
 # + Rltd - Related business application headers
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:head.001.001.04"
-}
 public type BusinessApplicationHeaderV04 record {|
     UnicodeChartsCode CharSet?;
     Party51Choice Fr;

--- a/iso20022/modules/payments_clearing_and_settlement/pacs.002.001.14.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/pacs.002.001.14.bal
@@ -31,9 +31,6 @@ public type Pacs002Envelope record {|
 # Defines the structure for Pacs002Document, which encapsulates the payment status report details.
 #
 # + FIToFIPmtStsRpt - Payment status report information
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:pacs.002.001.14"
-}
 public type Pacs002Document record {|
     FIToFIPaymentStatusReportV14 FIToFIPmtStsRpt;
 |};

--- a/iso20022/modules/payments_clearing_and_settlement/pacs.003.001.11.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/pacs.003.001.11.bal
@@ -108,9 +108,6 @@ public type DirectDebitTransactionInformation31 record {|
 # Defines the structure for Pacs003Document, which encapsulates the customer direct debit transaction details.
 #
 # + FIToFICstmrDrctDbt - Customer direct debit transaction information
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:pacs.003.001.11"
-}
 public type Pacs003Document record {|
     FIToFICustomerDirectDebitV11 FIToFICstmrDrctDbt;
 |};

--- a/iso20022/modules/payments_clearing_and_settlement/pacs.004.001.13.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/pacs.004.001.13.bal
@@ -16,9 +16,6 @@ public type Pacs004Envelope record {|
 # Defines the structure for Pacs004Document, which represents the root element of the Payment Return message.
 #
 # + PmtRtr - Contains the details of the payment return
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:pacs.004.001.13"
-}
 public type Pacs004Document record {|
     PaymentReturnV13 PmtRtr;
 |};

--- a/iso20022/modules/payments_clearing_and_settlement/pacs.008.001.12.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/pacs.008.001.12.bal
@@ -130,9 +130,6 @@ public type CreditTransferTransaction64 record {|
 # Defines the structure for Pacs008Document, which encapsulates the customer credit transfer transaction details.
 #
 # + FIToFICstmrCdtTrf - Customer credit transfer transaction information
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:pacs.008.001.12"
-}
 public type Pacs008Document record {|
     FIToFICustomerCreditTransferV12 FIToFICstmrCdtTrf;
 |};

--- a/iso20022/modules/payments_clearing_and_settlement/pacs.009.001.11.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/pacs.009.001.11.bal
@@ -112,9 +112,6 @@ public type CreditTransferTransaction62 record {|
 # Defines the structure for Pacs009Document, which encapsulates the financial institution credit transfer transaction information.
 #
 # + FICdtTrf - Financial institution credit transfer transaction information
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:pacs.009.001.11"
-}
 public type Pacs009Document record {|
     FinancialInstitutionCreditTransferV11 FICdtTrf;
 |};

--- a/iso20022/modules/payments_clearing_and_settlement/pacs.010.001.06.bal
+++ b/iso20022/modules/payments_clearing_and_settlement/pacs.010.001.06.bal
@@ -115,9 +115,6 @@ public type DirectDebitTransactionInformation33 record {|
 # Defines the structure for Pacs010Document, which encapsulates the financial institution direct debit transaction information.
 #
 # + FIDrctDbt - Financial institution direct debit transaction information
-@xmldata:Namespace {
-    uri: "urn:iso:std:iso:20022:tech:xsd:pacs.010.001.06"
-}
 public type Pacs010Document record {|
     FinancialInstitutionDirectDebitV06 FIDrctDbt;
 |};

--- a/iso20022/parser.bal
+++ b/iso20022/parser.bal
@@ -10,7 +10,7 @@ import ballerina/data.xmldata;
 # + recordType - A `typedesc` representing the Ballerina record type into which the XML will be parsed.
 # + return - The parsed Ballerina record if successful, or an error if the parsing fails.
 public isolated function fromIso20022(xml xmlContent, typedesc<record {}> recordType) returns record {}|error {
-    return xmldata:parseAsType(xmlContent, t = recordType);
+    return xmldata:parseAsType(xmlContent, {textFieldName: "content"}, recordType);
 }
 
 # Converts the given ISO 20022 record into XML format.
@@ -22,5 +22,5 @@ public isolated function fromIso20022(xml xmlContent, typedesc<record {}> record
 # + recordValue - The Ballerina record representing the ISO 20022 message to be converted.
 # + return - The generated XML if successful, or an error if the conversion fails.
 public isolated function toIso20022Xml(record {} recordValue) returns xml|error {
-    return xmldata:toXml(recordValue);
+    return xmldata:toXml(recordValue, {textFieldName: "content"});
 }


### PR DESCRIPTION
## Purpose
Enhance the ISO 20022 library by addressing an issue related to XML parsing when custom namespace prefixes are used. Previously, the library was unable to parse XML documents that included prefixed namespaces, leading to compatibility issues with real-world XML data.

## Goals
Ensure seamless parsing of XML documents with custom namespace prefixes by removing strict namespace requirements during parsing. This change improves the flexibility and usability of the ISO 20022 library, enabling it to handle a broader range of XML inputs without requiring manual namespace adjustments.